### PR TITLE
Rose gold recipe tier fix

### DIFF
--- a/overrides/kubejs/server_scripts/Recipes/Gregtech.js
+++ b/overrides/kubejs/server_scripts/Recipes/Gregtech.js
@@ -387,8 +387,17 @@ ServerEvents.recipes(event => {
       .duration(110)
       .EUt(GTValues.VA[GTValues.LV]);
 
-
-
+  
+  event.remove({id:'gtceu:mixer/rose_gold'})
+  event.recipes.gtceu.mixer('gtceu:mixer/rose_gold')
+      .itemInputs(['gtceu:copper_dust', '4x gtceu:gold_dust'])
+      .circuit(3)
+      .itemOutputs('5x gtceu:rose_gold_dust')
+      .duration(500)
+      .EUt(GTValues.VA[GTValues.LV]);
+    
+    
+    
 })
 
 

--- a/overrides/kubejs/server_scripts/Recipes/Gregtech.js
+++ b/overrides/kubejs/server_scripts/Recipes/Gregtech.js
@@ -381,13 +381,6 @@ ServerEvents.recipes(event => {
       .EUt(GTValues.VA[GTValues.LV]);
 
 
-  event.recipes.gtceu.lathe('gtceu:steel_ingot')
-      .itemInputs('gtceu:steel_ingot')
-      .itemOutputs('2x gtceu:steel_rod')
-      .duration(110)
-      .EUt(GTValues.VA[GTValues.LV]);
-
-  
   event.remove({id:'gtceu:mixer/rose_gold'})
   event.recipes.gtceu.mixer('gtceu:mixer/rose_gold')
       .itemInputs(['gtceu:copper_dust', '4x gtceu:gold_dust'])
@@ -395,9 +388,9 @@ ServerEvents.recipes(event => {
       .itemOutputs('5x gtceu:rose_gold_dust')
       .duration(500)
       .EUt(GTValues.VA[GTValues.LV]);
-    
-    
-    
+
+
+
 })
 
 


### PR DESCRIPTION
Moves the rose gold mixer recipe to LV to make it craftable.