### PR TITLE
Netherite line

### DIFF
--- a/overrides/kubejs/assets/gtceu/lang/en_us.json
+++ b/overrides/kubejs/assets/gtceu/lang/en_us.json
@@ -50,5 +50,6 @@
   "material.zanite": "Zanite",
   "material.ancient_debris": "Ancient Debris",
   "material.netherite_scrap": "Netherite Scrap",
-  "material.netherite_alloy": "Netherite Alloy"
+  "material.netherite_alloy": "Netherite Alloy",
+  "material.nether_sediment_sludge": "Nether Sediment Sludge"
 }

--- a/overrides/kubejs/assets/gtceu/lang/en_us.json
+++ b/overrides/kubejs/assets/gtceu/lang/en_us.json
@@ -47,5 +47,8 @@
 
   "block.gtceu.basic_alternator": "Basic Alternator",
   "material.mana_steel": "Mana Steel",
-  "material.zanite": "Zanite"
+  "material.zanite": "Zanite",
+  "material.ancient_debris": "Ancient Debris",
+  "material.netherite_scrap": "Netherite Scrap",
+  "material.netherite_alloy": "Netherite Alloy"
 }

--- a/overrides/kubejs/server_scripts/Recipes/Gregtech.js
+++ b/overrides/kubejs/server_scripts/Recipes/Gregtech.js
@@ -417,7 +417,7 @@ ServerEvents.recipes(event => {
   
   event.recipes.gtceu.mixer('gtceu:mixer/netherite_alloy')
     .itemInputs('2x gtceu:netherite_scrap_dust')
-    .itemInputs('2x gtceu:gold_dust')
+    .itemInputs('2x gtceu:rose_gold_dust')
     .itemOutputs('gtceu:netherite_alloy_dust')
     .duration(500)
     .EUt(GTValues.VA[GTValues.LV]);

--- a/overrides/kubejs/server_scripts/Recipes/Gregtech.js
+++ b/overrides/kubejs/server_scripts/Recipes/Gregtech.js
@@ -381,14 +381,55 @@ ServerEvents.recipes(event => {
       .EUt(GTValues.VA[GTValues.LV]);
 
 
-  event.recipes.gtceu.lathe('gtceu:steel_ingot')
-      .itemInputs('gtceu:steel_ingot')
-      .itemOutputs('2x gtceu:steel_rod')
-      .duration(110)
+  event.remove({id:'gtceu:mixer/rose_gold'})
+  event.recipes.gtceu.mixer('gtceu:mixer/rose_gold')
+      .itemInputs(['gtceu:copper_dust', '4x gtceu:gold_dust'])
+      .circuit(3)
+      .itemOutputs('5x gtceu:rose_gold_dust')
+      .duration(500)
       .EUt(GTValues.VA[GTValues.LV]);
 
 
 
 })
 
+//Netherite Line
+ServerEvents.recipes(event => { 
+  event.recipes.gtceu.macerator('gtceu:macerator/macerate_ancient_debris')
+    .itemInputs('minecraft:ancient_debris')
+    .itemOutputs('gtceu:ancient_debris_dust')
+    .duration(400)
+    .EUt(GTValues.VA[GTValues.ULV]);
+
+
+  event.recipes.gtceu.chemical_bath('gtceu:chemical_bath/purify_ancient_debris')
+    .itemInputs('gtceu:ancient_debris_dust')
+    .inputFluids('gtceu:nether_sediment_sludge 250')
+    .itemOutputs('gtceu:netherite_scrap_dust')
+    .chance(0.1)
+    .itemOutputs('gtceu:netherite_scrap_dust')
+    .chance(0.6)
+    .itemOutputs('gtceu:gold_dust')
+    .duration(200)
+    .EUt(GTValues.VA[GTValues.LV]);
+
+  
+  event.recipes.gtceu.mixer('gtceu:mixer/netherite_alloy')
+    .itemInputs('2x gtceu:netherite_scrap_dust')
+    .itemInputs('2x gtceu:gold_dust')
+    .itemOutputs('gtceu:netherite_alloy_dust')
+    .duration(500)
+    .EUt(GTValues.VA[GTValues.LV]);
+  
+
+  event.remove({id:'minecraft:netherite_ingot'})
+  event.recipes.gtceu.electric_blast_furnace('gtceu:electric_blast_furnace/netherite_from_netherite_alloy')
+    .itemInputs('gtceu:netherite_alloy_dust')
+    .inputFluids('gtceu:nitrogen 1000')
+    .itemOutputs('minecraft:netherite_ingot')
+    .blastFurnaceTemp(1200)
+    .duration(600)
+    .EUt(GTValues.VA[GTValues.MV]);
+
+})
 

--- a/overrides/kubejs/server_scripts/Recipes/Gregtech.js
+++ b/overrides/kubejs/server_scripts/Recipes/Gregtech.js
@@ -395,6 +395,7 @@ ServerEvents.recipes(event => {
 
 //Netherite Line
 ServerEvents.recipes(event => { 
+  event.remove({output:'minecraft:netherite_scrap'})
   event.recipes.gtceu.macerator('gtceu:macerator/macerate_ancient_debris')
     .itemInputs('minecraft:ancient_debris')
     .itemOutputs('gtceu:ancient_debris_dust')

--- a/overrides/kubejs/startup_scripts/Materials/MaterialGen.js
+++ b/overrides/kubejs/startup_scripts/Materials/MaterialGen.js
@@ -35,4 +35,19 @@ GTCEuStartupEvents.registry('gtceu:material', event => {
         .flags(GTMaterialFlags.GENERATE_PLATE, GTMaterialFlags.GENERATE_ROD)
         .color(0x9f0b21).iconSet(GTMaterialIconSet.RUBY)
 
+//Netherite Line Materials
+    event.create('ancient_debris')
+        .dust()
+        .color(0x422a25)
+
+    
+    event.create('netherite_scrap')
+        .dust()
+        .color(0x53332b).iconSet(GTMaterialIconSet.SHINY)
+
+
+    event.create('netherite_alloy')
+        .dust()
+        .color(0x393435).iconSet(GTMaterialIconSet.SHINY)
+
 })


### PR DESCRIPTION
Adds a processing line for netherite.
This should give a better yield of netherite from ancient debris and should gate netherite to late LV.
![Netherite Line](https://github.com/Frontiers-PackForge/CosmicFrontiers/assets/99605300/0d677cbd-dcfb-4f7a-9b59-67fd9d2f4b95)

Numbers and recipes can be tweaked as wanted.
