### PR TITLE
Nerf Ender Storage

### DIFF
--- a/overrides/kubejs/server_scripts/Recipes/Ender_Storage.js
+++ b/overrides/kubejs/server_scripts/Recipes/Ender_Storage.js
@@ -1,0 +1,17 @@
+ServerEvents.recipes( event =>{
+    event.remove({ output: 'endertanks:ender_tank' })
+    event.recipes.gtceu.assembler('endertank')
+    .itemInputs(['2x #gtceu:circuits/hv', '4x gtceu:obsidian_plate', '1x gtceu:lv_super_tank', '1x gtceu:ender_pearl_plate'])
+    .inputFluids('gtceu:blaze 2304')
+    .itemOutputs('endertanks:ender_tank')
+    .duration(140)
+    .EUt(GTValues.VA[GTValues.MV])
+
+    event.remove({ output: 'enderchests:ender_chest' })
+    event.recipes.gtceu.assembler('enderchest')
+    .itemInputs(['2x #gtceu:circuits/hv', '4x gtceu:obsidian_plate', '1x gtceu:lv_super_chest', '1x gtceu:ender_pearl_plate'])
+    .inputFluids('gtceu:blaze 2304')
+    .itemOutputs('enderchests:ender_chest')
+    .duration(140)
+    .EUt(GTValues.VA[GTValues.MV])
+})


### PR DESCRIPTION
Nerfs the Ender Storage recipes to be in line with the quest book.
The Recipes cost 2 HV and 4 LV circuits per storage, seems fair to me but could be changed.

Ender Chest:
![image](https://github.com/Frontiers-PackForge/CosmicFrontiers/assets/99605300/7e897d9e-1771-4014-9ce8-7b90ce484ddf)

Ender Tank:
![image](https://github.com/Frontiers-PackForge/CosmicFrontiers/assets/99605300/6355fb4e-b5ad-416d-9cab-ea66a072e57b)
