### PR TITLE
Flint and Steel Buff

### DIFF
--- a/overrides/kubejs/server_scripts/Recipes/Cosmic_Frontiers.js
+++ b/overrides/kubejs/server_scripts/Recipes/Cosmic_Frontiers.js
@@ -326,5 +326,15 @@ ServerEvents.recipes(event => {
                      L: 'cosmiccore:waxed_leather'
               })
        })
+
+       //Flint and Steel
+       event.replaceInput( {id: 'gtceu:shaped/flint_and_steel'}, 
+              'gtceu:small_steel_gear',
+              'gtceu:small_wrought_iron_gear'
+       )
+       event.replaceInput( {id: 'gtceu:shaped/flint_and_steel'}, 
+              'gtceu:small_steel_spring',
+              'gtceu:small_wrought_iron_spring'
+       )
 })
 

--- a/overrides/kubejs/startup_scripts/Materials/Cosmic_Frontiers_Materials.js
+++ b/overrides/kubejs/startup_scripts/Materials/Cosmic_Frontiers_Materials.js
@@ -271,6 +271,8 @@ GTCEuStartupEvents.registry('gtceu:material', event => {
             GTMaterialFlags.GENERATE_PLATE
         )
     GTMaterials.Aluminium.addFlags(GTMaterialFlags.GENERATE_ROTOR)
+    GTMaterials.WroughtIron.addFlags(GTMaterialFlags.GENERATE_SMALL_GEAR)
+    GTMaterials.WroughtIron.addFlags(GTMaterialFlags.GENERATE_SPRING_SMALL)
 })
 
 GTCEuStartupEvents.materialModification(event => {


### PR DESCRIPTION
Gates it with Wrought Iron instead of Steel which made it uncraftable pre-nether portal.
Quick buff for the unlucky ones who can't loot it or a fire charge.