### PR TITLE
Smallchanges 5.5

### DIFF
--- a/overrides/kubejs/server_scripts/Recipes/Ae2_Mods.js
+++ b/overrides/kubejs/server_scripts/Recipes/Ae2_Mods.js
@@ -456,6 +456,18 @@ ServerEvents.recipes(event => {
     .itemOutputs('arseng:source_cell_housing')
     .duration(80)
     .EUt(GTValues.VA[GTValues.LV]);
+  event.recipes.gtceu.assembler('megacells:mega_item_cell_housing')
+    .itemInputs(['3x gtceu:naquadah_alloy_plate','2x gtceu:fusion_glass','2x gtceu:hssg_single_cable','4x ae2:formation_core','4x ae2:annihilation_core'])
+    .inputFluids('gtceu:polybenzimidazole 576')
+    .itemOutputs('megacells:mega_item_cell_housing')
+    .duration(80)
+    .EUt(GTValues.VA[GTValues.LuV]);
+  event.recipes.gtceu.assembler('megacells:mega_fluid_cell_housing')
+    .itemInputs(['3x gtceu:trinium_plate','2x gtceu:fusion_glass','2x gtceu:hssg_single_cable','4x ae2:formation_core','4x ae2:annihilation_core'])
+    .inputFluids('gtceu:polybenzimidazole 576')
+    .itemOutputs('megacells:mega_fluid_cell_housing')
+    .duration(80)
+    .EUt(GTValues.VA[GTValues.LuV]);
   event.recipes.gtceu.assembler('arseng:basic_card_craft')
     .itemInputs(['16x gtceu:fine_red_alloy_wire', '4x gtceu:steel_plate', '4x gtceu:rose_gold_plate', '#gtceu:circuits/mv'])
     .inputFluids(`gtceu:soldering_alloy 144`)

--- a/overrides/kubejs/server_scripts/Recipes/Arboreal_Growth_Facility.js
+++ b/overrides/kubejs/server_scripts/Recipes/Arboreal_Growth_Facility.js
@@ -3,6 +3,7 @@ ServerEvents.recipes(event => {
         .itemInputs(['gtceu:hv_machine_hull', '4x #gtceu:circuits/hv', '2x gtceu:hv_robot_arm', 'gtceu:hv_electric_pump', 'minecraft:redstone_lamp', '2x gtceu:terrasteel_screw'])
         .inputFluids('gtceu:aether_augmented_sediment 1250')
         .itemOutputs('gtceu:arboreal_growth_facility')
+        .circuit(3)
         .duration(200)
         .EUt(GTValues.VA[GTValues.HV])
 

--- a/overrides/kubejs/server_scripts/Recipes/Chains/AetherAugmentedSediment.js
+++ b/overrides/kubejs/server_scripts/Recipes/Chains/AetherAugmentedSediment.js
@@ -3,7 +3,7 @@ ServerEvents.recipes(event => {
     event.recipes.gtceu.gas_collector('aether_air_collection')
         .outputFluids('gtceu:aether_air 10000')
         .duration(200)
-        .circuit(5)
+        .circuit(4)
         .dimension('aether:the_aether')
         .EUt(GTValues.VA[GTValues.HV]);
     //Liquid Aether Air

--- a/overrides/kubejs/server_scripts/Recipes/Chains/Floral_Recipes.js
+++ b/overrides/kubejs/server_scripts/Recipes/Chains/Floral_Recipes.js
@@ -379,7 +379,7 @@ ServerEvents.recipes(event => {
 
     event.recipes.gtceu.flora_nurturer('amber_aether')
         .notConsumable('1x aether:golden_oak_sapling')
-        .notConsumable('1x deep_aether:golden_heights_grass_block')
+        .notConsumable('1x aether:aether_dirt')
         .inputFluids('gtceu:aether_augmented_sediment 200')
         .itemOutputs('1x aether:golden_amber')
         .duration(120)

--- a/overrides/kubejs/server_scripts/Recipes/Chains/Floral_Recipes.js
+++ b/overrides/kubejs/server_scripts/Recipes/Chains/Floral_Recipes.js
@@ -401,7 +401,7 @@ ServerEvents.recipes(event => {
         .inputFluids('gtceu:aether_augmented_sediment 1250')
         .itemOutputs('1x gtceu:industrial_grade_floral_propagator')
         .duration(200)
-        .circuit(1)
+        .circuit(2)
         .EUt(GTValues.VA[GTValues.HV])
 
 

--- a/overrides/kubejs/server_scripts/Recipes/Chains/Floral_Recipes.js
+++ b/overrides/kubejs/server_scripts/Recipes/Chains/Floral_Recipes.js
@@ -395,6 +395,18 @@ ServerEvents.recipes(event => {
 
 
 
+    //Industrial Grade Floral Propagator controller block
+    event.recipes.gtceu.assembler('Industrial_Propagator')
+        .itemInputs(['1x gtceu:hv_machine_hull','4x #gtceu:circuits/hv','2x gtceu:hv_robot_arm','gtceu:hv_electric_pump','1x minecraft:redstone_lamp','2x gtceu:terrasteel_screw'])
+        .inputFluids('gtceu:aether_augmented_sediment 1250')
+        .itemOutputs('1x gtceu:industrial_grade_floral_propagator')
+        .duration(200)
+        .EUt(GTValues.VA[GTValues.HV])
+
+
+
+
+
 
     // event.recipes.gtceu.('cosmiccore:pearl_cultivation')
     // .notConsumable('nethersdelight:propelpearl')

--- a/overrides/kubejs/server_scripts/Recipes/Chains/Floral_Recipes.js
+++ b/overrides/kubejs/server_scripts/Recipes/Chains/Floral_Recipes.js
@@ -401,6 +401,7 @@ ServerEvents.recipes(event => {
         .inputFluids('gtceu:aether_augmented_sediment 1250')
         .itemOutputs('1x gtceu:industrial_grade_floral_propagator')
         .duration(200)
+        .circuit(1)
         .EUt(GTValues.VA[GTValues.HV])
 
 

--- a/overrides/kubejs/server_scripts/Recipes/Chains/PlatLine.js
+++ b/overrides/kubejs/server_scripts/Recipes/Chains/PlatLine.js
@@ -69,7 +69,7 @@ ServerEvents.recipes(event => {
         .inputFluids('gtceu:hydrogen_peroxide 1000')
         .inputFluids('gtceu:ammonia 6000')
         .outputFluids('gtceu:hydrazine 1000')
-        .outputFluids('gtceu:water 2000')
+        .outputFluids('minecraft:water 2000')
         .duration(320)
         .EUt(GTValues.VA[GTValues.MV]);
     //Bad Plat Recipe

--- a/overrides/kubejs/server_scripts/Recipes/Chains/Prisma.js
+++ b/overrides/kubejs/server_scripts/Recipes/Chains/Prisma.js
@@ -71,5 +71,16 @@ ServerEvents.recipes(event => {
         .duration(240)
         .EUt(GTValues.VA[GTValues.HV]);
 
-
+    //Chromatic Floatation Plant
+    event.shaped('cosmiccore:chromatic_flotation_plant',[
+        'ABA',
+        'CDC',
+        'EBE'
+    ], {
+        A: 'gtceu:tungsten_steel_drum',
+        B: '#gtceu:circuits/luv',
+        C: 'gtceu:iv_electric_pump',
+        D: 'gtceu:iv_machine_hull',
+        E: 'gtceu:iv_conveyor_module'
+    })
 })


### PR DESCRIPTION
-changed golden amber recipe inputs in flora nurturer
-changed aether air circuit from 5 to 4
-added a recipe for the industrial grade floral propagator(added circuit to this and the industrial arboreal growth chamber)
-added recipes for mega fluid/item cell housings(i think they are fair)
-changed hydrazine from gtceu:water to minecraft:water to properly output
-added recipe for the chromatic flotation plant controller block(open to being changed, will not craft till pushed into main)