### PR TITLE
Ultimine Grouping for special Malum & Inegrated Dynamics

### DIFF
--- a/overrides/defaultconfigs/ftbultimine/ftbultimine-server.snbt
+++ b/overrides/defaultconfigs/ftbultimine/ftbultimine-server.snbt
@@ -23,6 +23,9 @@
 		"minecraft:base_stone_overworld"
 		"c:*_ores"
 		"forge:ores/*"
+		"cosmicfrontiers:soulwood_ultimine_group"
+		"cosmicfrontiers:runewood_ultimine_group"
+		"cosmicfrontiers:menril_ultimine_group"
 	]
 	
 	# These tags will be considered the same block when checking for blocks to Ultimine in shaped mining modes

--- a/overrides/kubejs/server_scripts/Recipes/IntDynamics.js
+++ b/overrides/kubejs/server_scripts/Recipes/IntDynamics.js
@@ -1,3 +1,8 @@
+ServerEvents.tags('block', event => {
+  event.add('cosmicfrontiers:menril_ultimine_group', 'integrateddynamics:menril_log_filled')
+  event.add('cosmicfrontiers:menril_ultimine_group', 'integrateddynamics:menril_log')
+})
+
 ServerEvents.recipes(event => {
   //Waxed Leather
   event.shaped('cosmiccore:waxed_leather', [

--- a/overrides/kubejs/server_scripts/Recipes/Malum.js
+++ b/overrides/kubejs/server_scripts/Recipes/Malum.js
@@ -5,7 +5,15 @@ ServerEvents.tags('item', event => {
   event.add('c:hidden_from_recipe_viewers', massHideMalum)
   event.remove('forge:gems/quartz', 'malum:natural_quartz_ore')
   event.remove('forge:gems/quartz', 'malum:deepslate_quartz_ore')
+})
 
+ServerEvents.tags('block', event => {
+  event.add('cosmicfrontiers:soulwood_ultimine_group', 'malum:exposed_soulwood_log')
+  event.add('cosmicfrontiers:soulwood_ultimine_group', 'malum:soulwood_log')
+  event.add('cosmicfrontiers:soulwood_ultimine_group', 'malum:blighted_soulwood')
+
+  event.add('cosmicfrontiers:runewood_ultimine_group', 'malum:exposed_runewood_log')
+  event.add('cosmicfrontiers:runewood_ultimine_group', 'malum:runewood_log')
 })
 
 ServerEvents.recipes(event => {


### PR DESCRIPTION
Ultimine will now work for Malum's normal and Exposed (Soul|Rune)wood logs, as well as ID's normal and Enriched menril logs

![image](https://github.com/user-attachments/assets/7b35653c-20d0-4ccf-be22-54bb0966318d)

closes #282 