### PR TITLE
fix peanut unification for roasted nuts & peanuts

### DIFF
--- a/overrides/kubejs/server_scripts/Recipes/Cosmic_Frontiers.js
+++ b/overrides/kubejs/server_scripts/Recipes/Cosmic_Frontiers.js
@@ -22,8 +22,6 @@ ServerEvents.tags('item', event => {
        event.add('curios:head', 'kubejs:nano_respirator')
        event.add('curios:charm', 'gtceu:hv_item_magnet')
        event.add('curios:charm', 'gtceu:lv_item_magnet')
-       event.add('frontiers:peanut', 'croptopia:peanut')
-       event.add('frontiers:peanut', 'vintagedelight:peanut_crop')
 })
 //Generator Removal - WILL RETURN WITH UH, """BETTER""" CREATE FUNCTIONALITY
 // yeet('gtceu:lv_combustion')

--- a/overrides/kubejs/server_scripts/Recipes/Foods/Others.js
+++ b/overrides/kubejs/server_scripts/Recipes/Foods/Others.js
@@ -124,4 +124,8 @@ ServerEvents.recipes(event => {
         .itemOutputs('2x delightful:nut_dough')
         .EUt(GTValues.VA[GTValues.LV])
         .duration(400);
+
+    event.replaceInput({ output: 'croptopia:roasted_nuts' }, '#forge:nuts', '#frontiers:croptopia/nuts')
+    event.replaceInput({ input: '#forge:peanut' }, 'vintagedelight:peanut', '#forge:peanuts')
+
 })

--- a/overrides/kubejs/server_scripts/Recipes/Foods/Tags.js
+++ b/overrides/kubejs/server_scripts/Recipes/Foods/Tags.js
@@ -5,6 +5,8 @@ ServerEvents.tags('item', event => {
     event.add('forge:cabbage', 'farmersdelight:cabbage')
     event.add('forge:tomatoes', 'farmersdelight:tomato')
     event.add('forge:onions', 'farmersdelight:onion')
+    event.add('frontiers:croptopia/nuts', ['croptopia:almond', 'croptopia:pecan', 'croptopia:walnut']) // non peanut nuts from croptopia used for roasted nuts recipe
+    event.add('forge:peanuts', ['vintagedelight:peanut', 'croptopia:peanut']) // this is driving me *nuts* why does one have (s)
 })
 
 ServerEvents.tags('fluid', event => {


### PR DESCRIPTION
edited tags and smelting recipes

also removed the frontiers peanut tag surely that's not useful why is it there I can't find a use please don't be useful