### PR TITLE
Add missing material flags to manasteel

### DIFF
--- a/overrides/kubejs/startup_scripts/Materials/Botania_Materials.js
+++ b/overrides/kubejs/startup_scripts/Materials/Botania_Materials.js
@@ -84,7 +84,11 @@ GTCEuStartupEvents.registry('gtceu:material', event => {
         .flags(
             GTMaterialFlags.GENERATE_FINE_WIRE,
             GTMaterialFlags.GENERATE_PLATE,
-            GTMaterialFlags.GENERATE_ROD)
+            GTMaterialFlags.GENERATE_ROD,
+            GTMaterialFlags.GENERATE_LONG_ROD,
+            GTMaterialFlags.GENERATE_BOLT_SCREW,
+            GTMaterialFlags.GENERATE_GEAR,)
+
     event.create('annealed_manasteel')
         .ingot()
         .liquid()
@@ -102,7 +106,6 @@ GTCEuStartupEvents.registry('gtceu:material', event => {
             GTMaterialFlags.GENERATE_FINE_WIRE,
             GTMaterialFlags.NO_SMELTING
         )
-
 
     event.create('elementium')
         .color(0xf472c6)


### PR DESCRIPTION
Adds long rod, bolt, and gear flags to manasteel to fix missing recipes for manasteel wirecutter, electric screwdriver, and buzzsaw