### PR TITLE
Remove duplicate recipe for waxed leather

### DIFF
--- a/overrides/kubejs/server_scripts/Recipes/IntDynamics.js
+++ b/overrides/kubejs/server_scripts/Recipes/IntDynamics.js
@@ -4,16 +4,6 @@ ServerEvents.tags('block', event => {
 })
 
 ServerEvents.recipes(event => {
-  //Waxed Leather
-  event.shaped('cosmiccore:waxed_leather', [
-    ' W ',
-    'WLW',
-    ' W '
-  ], {
-    W: 'minecraft:honeycomb',
-    L: 'minecraft:leather'
-  }
-  )
   // event.remove({ mod: 'integrateddynamics' })
   //Crafting Recipes
   // event.remove({ output: 'integrateddynamics:drying_basin' })


### PR DESCRIPTION
Two recipes diverged in a yellow wood. The recipe less traveled was excised from existence.