### PR TITLE
Apoth manasteel affix fix

### DIFF
--- a/overrides/config/apotheosis/adventure.cfg
+++ b/overrides/config/apotheosis/adventure.cfg
@@ -10,6 +10,8 @@ affixes {
         minecraft:iron_sword|sword
         minecraft:shulker_shell|none
         gtceu:manasteel_pickaxe|pickaxe
+        gtceu:elementium_pickaxe|pickaxe
+        gtceu:terrasteel_pickaxe|pickaxe
         gtceu:aluminium_pickaxe|pickaxe
         gtceu:iron_pickaxe|pickaxe
         gtceu:titanium_pickaxe|pickaxe
@@ -34,6 +36,8 @@ affixes {
         gtceu:blue_steel_pickaxe|pickaxe
         gtceu:hsse_pickaxe|pickaxe
         gtceu:manasteel_hammer|pickaxe
+        gtceu:elementium_hammer|pickaxe
+        gtceu:terrasteel_hammer|pickaxe
         gtceu:aluminium_hammer|pickaxe
         gtceu:iron_hammer|pickaxe
         gtceu:titanium_hammer|pickaxe
@@ -57,6 +61,9 @@ affixes {
         gtceu:red_steel_hammer|pickaxe
         gtceu:blue_steel_hammer|pickaxe
         gtceu:hsse_hammer|pickaxe
+        gtceu:manasteel_mining_hammer|pickaxe
+        gtceu:elementium_mining_hammer|pickaxe
+        gtceu:terrasteel_mining_hammer|pickaxe
         gtceu:aluminium_mining_hammer|pickaxe
         gtceu:iron_mining_hammer|pickaxe
         gtceu:titanium_mining_hammer|pickaxe
@@ -81,6 +88,8 @@ affixes {
         gtceu:blue_steel_mining_hammer|pickaxe
         gtceu:hsse_mining_hammer|pickaxe
         gtceu:lv_manasteel_drill|pickaxe
+        gtceu:lv_elementium_drill|pickaxe
+        gtceu:lv_terrasteel_drill|pickaxe
         gtceu:lv_aluminium_drill|pickaxe
         gtceu:lv_iron_drill|pickaxe
         gtceu:lv_titanium_drill|pickaxe
@@ -105,6 +114,8 @@ affixes {
         gtceu:lv_blue_steel_drill|pickaxe
         gtceu:lv_hsse_drill|pickaxe
         gtceu:mv_manasteel_drill|pickaxe
+        gtceu:mv_elementium_drill|pickaxe
+        gtceu:mv_terrasteel_drill|pickaxe
         gtceu:mv_aluminium_drill|pickaxe
         gtceu:mv_iron_drill|pickaxe
         gtceu:mv_titanium_drill|pickaxe
@@ -129,6 +140,8 @@ affixes {
         gtceu:mv_blue_steel_drill|pickaxe
         gtceu:mv_hsse_drill|pickaxe
         gtceu:hv_manasteel_drill|pickaxe
+        gtceu:hv_elementium_drill|pickaxe
+        gtceu:hv_terrasteel_drill|pickaxe
         gtceu:hv_aluminium_drill|pickaxe
         gtceu:hv_iron_drill|pickaxe
         gtceu:hv_titanium_drill|pickaxe
@@ -153,6 +166,8 @@ affixes {
         gtceu:hv_blue_steel_drill|pickaxe
         gtceu:hv_hsse_drill|pickaxe
         gtceu:ev_manasteel_drill|pickaxe
+        gtceu:ev_elementium_drill|pickaxe
+        gtceu:ev_terrasteel_drill|pickaxe
         gtceu:ev_aluminium_drill|pickaxe
         gtceu:ev_iron_drill|pickaxe
         gtceu:ev_titanium_drill|pickaxe
@@ -177,6 +192,8 @@ affixes {
         gtceu:ev_blue_steel_drill|pickaxe
         gtceu:ev_hsse_drill|pickaxe
         gtceu:iv_manasteel_drill|pickaxe
+        gtceu:iv_elementium_drill|pickaxe
+        gtceu:iv_terrasteel_drill|pickaxe
         gtceu:iv_aluminium_drill|pickaxe
         gtceu:iv_iron_drill|pickaxe
         gtceu:iv_titanium_drill|pickaxe
@@ -201,6 +218,8 @@ affixes {
         gtceu:iv_blue_steel_drill|pickaxe
         gtceu:iv_hsse_drill|pickaxe
         gtceu:manasteel_wrench|pickaxe
+        gtceu:elementium_wrench|pickaxe
+        gtceu:terrasteel_wrench|pickaxe
         gtceu:aluminium_wrench|pickaxe
         gtceu:iron_wrench|pickaxe
         gtceu:titanium_wrench|pickaxe
@@ -225,6 +244,8 @@ affixes {
         gtceu:blue_steel_wrench|pickaxe
         gtceu:hsse_wrench|pickaxe
         gtceu:lv_manasteel_wrench|pickaxe
+        gtceu:lv_elementium_wrench|pickaxe
+        gtceu:lv_terrasteel_wrench|pickaxe
         gtceu:lv_aluminium_wrench|pickaxe
         gtceu:lv_iron_wrench|pickaxe
         gtceu:lv_titanium_wrench|pickaxe
@@ -249,6 +270,8 @@ affixes {
         gtceu:lv_blue_steel_wrench|pickaxe
         gtceu:lv_hsse_wrench|pickaxe
         gtceu:hv_manasteel_wrench|pickaxe
+        gtceu:hv_elementium_wrench|pickaxe
+        gtceu:hv_terrasteel_wrench|pickaxe
         gtceu:hv_aluminium_wrench|pickaxe
         gtceu:hv_iron_wrench|pickaxe
         gtceu:hv_titanium_wrench|pickaxe
@@ -273,6 +296,8 @@ affixes {
         gtceu:hv_blue_steel_wrench|pickaxe
         gtceu:hv_hsse_wrench|pickaxe
         gtceu:iv_manasteel_wrench|pickaxe
+        gtceu:iv_elementium_wrench|pickaxe
+        gtceu:iv_terrasteel_wrench|pickaxe
         gtceu:iv_aluminium_wrench|pickaxe
         gtceu:iv_iron_wrench|pickaxe
         gtceu:iv_titanium_wrench|pickaxe
@@ -297,6 +322,8 @@ affixes {
         gtceu:iv_blue_steel_wrench|pickaxe
         gtceu:iv_hsse_wrench|pickaxe
         gtceu:manasteel_wire_cutter|pickaxe
+        gtceu:elementium_wire_cutter|pickaxe
+        gtceu:terrasteel_wire_cutter|pickaxe
         gtceu:aluminium_wire_cutter|pickaxe
         gtceu:iron_wire_cutter|pickaxe
         gtceu:titanium_wire_cutter|pickaxe
@@ -321,6 +348,8 @@ affixes {
         gtceu:blue_steel_wire_cutter|pickaxe
         gtceu:hsse_wire_cutter|pickaxe
         gtceu:lv_manasteel_wirecutter|pickaxe
+        gtceu:lv_elementium_wire_cutter|pickaxe
+        gtceu:lv_terrasteel_wire_cutter|pickaxe
         gtceu:lv_aluminium_wirecutter|pickaxe
         gtceu:lv_iron_wirecutter|pickaxe
         gtceu:lv_titanium_wirecutter|pickaxe
@@ -345,6 +374,8 @@ affixes {
         gtceu:lv_blue_steel_wirecutter|pickaxe
         gtceu:lv_hsse_wirecutter|pickaxe
         gtceu:hv_manasteel_wirecutter|pickaxe
+        gtceu:hv_elementium_wire_cutter|pickaxe
+        gtceu:hv_terrasteel_wire_cutter|pickaxe
         gtceu:hv_aluminium_wirecutter|pickaxe
         gtceu:hv_iron_wirecutter|pickaxe
         gtceu:hv_titanium_wirecutter|pickaxe
@@ -369,6 +400,8 @@ affixes {
         gtceu:hv_blue_steel_wirecutter|pickaxe
         gtceu:hv_hsse_wirecutter|pickaxe
         gtceu:iv_manasteel_wirecutter|pickaxe
+        gtceu:iv_elementium_wire_cutter|pickaxe
+        gtceu:iv_terrasteel_wire_cutter|pickaxe
         gtceu:iv_aluminium_wirecutter|pickaxe
         gtceu:iv_iron_wirecutter|pickaxe
         gtceu:iv_titanium_wirecutter|pickaxe
@@ -393,6 +426,8 @@ affixes {
         gtceu:iv_blue_steel_wirecutter|pickaxe
         gtceu:iv_hsse_wirecutter|pickaxe
         gtceu:manasteel_shovel|shovel
+        gtceu:elementium_shovel|shovel
+        gtceu:terrasteel_shovel|shovel
         gtceu:aluminium_shovel|shovel
         gtceu:iron_shovel|shovel
         gtceu:titanium_shovel|shovel
@@ -417,6 +452,8 @@ affixes {
         gtceu:blue_steel_shovel|shovel
         gtceu:hsse_shovel|shovel
         gtceu:manasteel_spade|shovel
+        gtceu:elementium_spade|shovel
+        gtceu:terrasteel_spade|shovel
         gtceu:aluminium_spade|shovel
         gtceu:iron_spade|shovel
         gtceu:titanium_spade|shovel

--- a/overrides/config/apotheosis/adventure.cfg
+++ b/overrides/config/apotheosis/adventure.cfg
@@ -9,6 +9,7 @@ affixes {
     S:"Equipment Type Overrides" <
         minecraft:iron_sword|sword
         minecraft:shulker_shell|none
+        gtceu:manasteel_pickaxe|pickaxe
         gtceu:aluminium_pickaxe|pickaxe
         gtceu:iron_pickaxe|pickaxe
         gtceu:titanium_pickaxe|pickaxe
@@ -32,6 +33,7 @@ affixes {
         gtceu:red_steel_pickaxe|pickaxe
         gtceu:blue_steel_pickaxe|pickaxe
         gtceu:hsse_pickaxe|pickaxe
+        gtceu:manasteel_hammer|pickaxe
         gtceu:aluminium_hammer|pickaxe
         gtceu:iron_hammer|pickaxe
         gtceu:titanium_hammer|pickaxe
@@ -78,6 +80,7 @@ affixes {
         gtceu:red_steel_mining_hammer|pickaxe
         gtceu:blue_steel_mining_hammer|pickaxe
         gtceu:hsse_mining_hammer|pickaxe
+        gtceu:lv_manasteel_drill|pickaxe
         gtceu:lv_aluminium_drill|pickaxe
         gtceu:lv_iron_drill|pickaxe
         gtceu:lv_titanium_drill|pickaxe
@@ -101,6 +104,7 @@ affixes {
         gtceu:lv_red_steel_drill|pickaxe
         gtceu:lv_blue_steel_drill|pickaxe
         gtceu:lv_hsse_drill|pickaxe
+        gtceu:mv_manasteel_drill|pickaxe
         gtceu:mv_aluminium_drill|pickaxe
         gtceu:mv_iron_drill|pickaxe
         gtceu:mv_titanium_drill|pickaxe
@@ -124,6 +128,7 @@ affixes {
         gtceu:mv_red_steel_drill|pickaxe
         gtceu:mv_blue_steel_drill|pickaxe
         gtceu:mv_hsse_drill|pickaxe
+        gtceu:hv_manasteel_drill|pickaxe
         gtceu:hv_aluminium_drill|pickaxe
         gtceu:hv_iron_drill|pickaxe
         gtceu:hv_titanium_drill|pickaxe
@@ -147,6 +152,7 @@ affixes {
         gtceu:hv_red_steel_drill|pickaxe
         gtceu:hv_blue_steel_drill|pickaxe
         gtceu:hv_hsse_drill|pickaxe
+        gtceu:ev_manasteel_drill|pickaxe
         gtceu:ev_aluminium_drill|pickaxe
         gtceu:ev_iron_drill|pickaxe
         gtceu:ev_titanium_drill|pickaxe
@@ -170,6 +176,7 @@ affixes {
         gtceu:ev_red_steel_drill|pickaxe
         gtceu:ev_blue_steel_drill|pickaxe
         gtceu:ev_hsse_drill|pickaxe
+        gtceu:iv_manasteel_drill|pickaxe
         gtceu:iv_aluminium_drill|pickaxe
         gtceu:iv_iron_drill|pickaxe
         gtceu:iv_titanium_drill|pickaxe
@@ -193,6 +200,7 @@ affixes {
         gtceu:iv_red_steel_drill|pickaxe
         gtceu:iv_blue_steel_drill|pickaxe
         gtceu:iv_hsse_drill|pickaxe
+        gtceu:manasteel_wrench|pickaxe
         gtceu:aluminium_wrench|pickaxe
         gtceu:iron_wrench|pickaxe
         gtceu:titanium_wrench|pickaxe
@@ -216,6 +224,7 @@ affixes {
         gtceu:red_steel_wrench|pickaxe
         gtceu:blue_steel_wrench|pickaxe
         gtceu:hsse_wrench|pickaxe
+        gtceu:lv_manasteel_wrench|pickaxe
         gtceu:lv_aluminium_wrench|pickaxe
         gtceu:lv_iron_wrench|pickaxe
         gtceu:lv_titanium_wrench|pickaxe
@@ -239,6 +248,7 @@ affixes {
         gtceu:lv_red_steel_wrench|pickaxe
         gtceu:lv_blue_steel_wrench|pickaxe
         gtceu:lv_hsse_wrench|pickaxe
+        gtceu:hv_manasteel_wrench|pickaxe
         gtceu:hv_aluminium_wrench|pickaxe
         gtceu:hv_iron_wrench|pickaxe
         gtceu:hv_titanium_wrench|pickaxe
@@ -262,6 +272,7 @@ affixes {
         gtceu:hv_red_steel_wrench|pickaxe
         gtceu:hv_blue_steel_wrench|pickaxe
         gtceu:hv_hsse_wrench|pickaxe
+        gtceu:iv_manasteel_wrench|pickaxe
         gtceu:iv_aluminium_wrench|pickaxe
         gtceu:iv_iron_wrench|pickaxe
         gtceu:iv_titanium_wrench|pickaxe
@@ -285,6 +296,7 @@ affixes {
         gtceu:iv_red_steel_wrench|pickaxe
         gtceu:iv_blue_steel_wrench|pickaxe
         gtceu:iv_hsse_wrench|pickaxe
+        gtceu:manasteel_wire_cutter|pickaxe
         gtceu:aluminium_wire_cutter|pickaxe
         gtceu:iron_wire_cutter|pickaxe
         gtceu:titanium_wire_cutter|pickaxe
@@ -308,6 +320,79 @@ affixes {
         gtceu:red_steel_wire_cutter|pickaxe
         gtceu:blue_steel_wire_cutter|pickaxe
         gtceu:hsse_wire_cutter|pickaxe
+        gtceu:lv_manasteel_wirecutter|pickaxe
+        gtceu:lv_aluminium_wirecutter|pickaxe
+        gtceu:lv_iron_wirecutter|pickaxe
+        gtceu:lv_titanium_wirecutter|pickaxe
+        gtceu:lv_neutronium_wirecutter|pickaxe
+        gtceu:lv_duranium_wirecutter|pickaxe
+        gtceu:lv_bronze_wirecutter|pickaxe
+        gtceu:lv_diamond_wirecutter|pickaxe
+        gtceu:lv_invar_wirecutter|pickaxe
+        gtceu:lv_starling_silver_wirecutter|pickaxe
+        gtceu:lv_rose_gold_wirecutter|pickaxe
+        gtceu:lv_stainless_steel_wirecutter|pickaxe
+        gtceu:lv_steel_wirecutter|pickaxe
+        gtceu:lv_ultimet_wirecutter|pickaxe
+        gtceu:lv_wrought_iron_wirecutter|pickaxe
+        gtceu:lv_tungsten_carbide_wirecutter|pickaxe
+        gtceu:lv_damascus_steel_wirecutter|pickaxe
+        gtceu:lv_tungsten_steel_wirecutter|pickaxe
+        gtceu:lv_cobalt_brass_wirecutter|pickaxe
+        gtceu:lv_vanadium_steel_wirecutter|pickaxe
+        gtceu:lv_naquadah_alloy_wirecutter|pickaxe
+        gtceu:lv_red_steel_wirecutter|pickaxe
+        gtceu:lv_blue_steel_wirecutter|pickaxe
+        gtceu:lv_hsse_wirecutter|pickaxe
+        gtceu:hv_manasteel_wirecutter|pickaxe
+        gtceu:hv_aluminium_wirecutter|pickaxe
+        gtceu:hv_iron_wirecutter|pickaxe
+        gtceu:hv_titanium_wirecutter|pickaxe
+        gtceu:hv_neutronium_wirecutter|pickaxe
+        gtceu:hv_duranium_wirecutter|pickaxe
+        gtceu:hv_bronze_wirecutter|pickaxe
+        gtceu:hv_diamond_wirecutter|pickaxe
+        gtceu:hv_invar_wirecutter|pickaxe
+        gtceu:hv_starling_silver_wirecutter|pickaxe
+        gtceu:hv_rose_gold_wirecutter|pickaxe
+        gtceu:hv_stainless_steel_wirecutter|pickaxe
+        gtceu:hv_steel_wirecutter|pickaxe
+        gtceu:hv_ultimet_wirecutter|pickaxe
+        gtceu:hv_wrought_iron_wirecutter|pickaxe
+        gtceu:hv_tungsten_carbide_wirecutter|pickaxe
+        gtceu:hv_damascus_steel_wirecutter|pickaxe
+        gtceu:hv_tungsten_steel_wirecutter|pickaxe
+        gtceu:hv_cobalt_brass_wirecutter|pickaxe
+        gtceu:hv_vanadium_steel_wirecutter|pickaxe
+        gtceu:hv_naquadah_alloy_wirecutter|pickaxe
+        gtceu:hv_red_steel_wirecutter|pickaxe
+        gtceu:hv_blue_steel_wirecutter|pickaxe
+        gtceu:hv_hsse_wirecutter|pickaxe
+        gtceu:iv_manasteel_wirecutter|pickaxe
+        gtceu:iv_aluminium_wirecutter|pickaxe
+        gtceu:iv_iron_wirecutter|pickaxe
+        gtceu:iv_titanium_wirecutter|pickaxe
+        gtceu:iv_neutronium_wirecutter|pickaxe
+        gtceu:iv_duranium_wirecutter|pickaxe
+        gtceu:iv_bronze_wirecutter|pickaxe
+        gtceu:iv_diamond_wirecutter|pickaxe
+        gtceu:iv_invar_wirecutter|pickaxe
+        gtceu:iv_starling_silver_wirecutter|pickaxe
+        gtceu:iv_rose_gold_wirecutter|pickaxe
+        gtceu:iv_stainless_steel_wirecutter|pickaxe
+        gtceu:iv_steel_wirecutter|pickaxe
+        gtceu:iv_ultimet_wirecutter|pickaxe
+        gtceu:iv_wrought_iron_wirecutter|pickaxe
+        gtceu:iv_tungsten_carbide_wirecutter|pickaxe
+        gtceu:iv_damascus_steel_wirecutter|pickaxe
+        gtceu:iv_tungsten_steel_wirecutter|pickaxe
+        gtceu:iv_cobalt_brass_wirecutter|pickaxe
+        gtceu:iv_vanadium_steel_wirecutter|pickaxe
+        gtceu:iv_naquadah_alloy_wirecutter|pickaxe
+        gtceu:iv_red_steel_wirecutter|pickaxe
+        gtceu:iv_blue_steel_wirecutter|pickaxe
+        gtceu:iv_hsse_wirecutter|pickaxe
+        gtceu:manasteel_shovel|shovel
         gtceu:aluminium_shovel|shovel
         gtceu:iron_shovel|shovel
         gtceu:titanium_shovel|shovel
@@ -331,6 +416,7 @@ affixes {
         gtceu:red_steel_shovel|shovel
         gtceu:blue_steel_shovel|shovel
         gtceu:hsse_shovel|shovel
+        gtceu:manasteel_spade|shovel
         gtceu:aluminium_spade|shovel
         gtceu:iron_spade|shovel
         gtceu:titanium_spade|shovel
@@ -486,5 +572,3 @@ spawners {
     # Default: 0.11; Range: [0.0 ~ 1.0]
     S:"Spawner Value Chance"=0.11
 }
-
-


### PR DESCRIPTION
Should fix #342 
Also fixes the same for electric wirecutters, giving them pickage affixes too