### PR TITLE
Add icon for log quest to prevent lag

### DIFF
--- a/overrides/config/ftbquests/quests/chapters/exoplanet_03s9__earth.snbt
+++ b/overrides/config/ftbquests/quests/chapters/exoplanet_03s9__earth.snbt
@@ -307,6 +307,7 @@
 			}]
 			subtitle: "You'll need this"
 			tasks: [{
+				icon: "minecraft:oak_log"
 				id: "78F01614D58508A8"
 				item: {
 					Count: 1
@@ -315,6 +316,7 @@
 						"ftbfiltersystem:filter": "item_tag(minecraft:logs)"
 					}
 				}
+				title: "Any wood log"
 				type: "item"
 			}]
 			title: "Get Some Bi- I mean Wood"


### PR DESCRIPTION
Icon for the log quest in First Steps chapter isn't set, so the smart filter lag is absolutely crazy. Fixed by setting an icon (oak log)