### PR TITLE
Add Sun Fern recipes to the Flora Nurturer

### DIFF
--- a/overrides/kubejs/server_scripts/Recipes/Cosmic_Frontiers.js
+++ b/overrides/kubejs/server_scripts/Recipes/Cosmic_Frontiers.js
@@ -759,8 +759,22 @@ ServerEvents.recipes(event => {
               .duration(10)
               .EUt(GTValues.VA[GTValues.LV] / 2);
 
-
-
+       //sun fern flora nurturer recipes -- placed here since the ice fern ones are autogenned(?) while these aren't
+       event.recipes.gtceu.flora_nurturer('cosmiccore:sun_fern_cultivation_sludge')
+              .notConsumable('legendarysurvivaloverhaul:sun_fern_leaf')
+              .notConsumable('minecraft:moss_block')
+              .inputFluids(Fluid.of('gtceu:nether_sediment_sludge', 500))
+              .itemOutputs('legendarysurvivaloverhaul:sun_fern_leaf')
+              .chancedOutput(Item.of('legendarysurvivaloverhaul:sun_fern_leaf', 1), 2500, 50)
+              .duration(160)
+              .EUt(15);
+       event.recipes.gtceu.flora_nurturer('cosmiccore:sun_fern_cultivation_nutrient_solution')
+              .notConsumable('legendarysurvivaloverhaul:sun_fern_leaf')
+              .notConsumable('minecraft:moss_block')
+              .inputFluids(Fluid.of('gtceu:nutrient_solution', 50))
+              .itemOutputs('16x legendarysurvivaloverhaul:sun_fern_leaf')
+              .duration(160)
+              .EUt(60);
 
        //TODO - Mechanical Flower Recipes
        event.recipes.botania.runic_altar('gtceu:mana_simulator', ['#gtceu:circuits/ev', 'gtceu:terrasteel_octal_wire', 'gtceu:terrasteel_octal_wire', 'gtceu:terrasteel_plate', 'gtceu:terrasteel_plate', 'gtceu:terrasteel_plate', 'gtceu:terrasteel_plate', 'botania:gourmaryllis', 'botania:entropinnyum', '#gtceu:circuits/ev', 'botania:narslimmus', 'botania:spectrolus', 'botania:blacker_lotus'], 250000)


### PR DESCRIPTION
The new recipes are nearly identical to the ice fern ones, minus the inputted and outputted ferns. If the lack of recipes for sun ferns has already been fixed in Cosmic Core in dev builds, feel free to reject this PR on the spot—too lazy to do what's required to get the devpack actually working rn >.< 