### PR TITLE
Add missing UG fungi recipes

### DIFF
--- a/overrides/kubejs/server_scripts/Recipes/Arboreal_Growth_Facility.js
+++ b/overrides/kubejs/server_scripts/Recipes/Arboreal_Growth_Facility.js
@@ -278,4 +278,23 @@ ServerEvents.recipes(event => {
                 .EUt(GTValues.VA[GTValues.MV] / 2)
         }
     })
+
+    let FungiUG = [
+        'undergarden:veil',,
+        'undergarden:ink',
+        'undergarden:indigo',
+    ]
+
+    FungiUG.forEach(tree => {
+        event.recipes.gtceu.arboreal_growth_facility(`${tree}_growth_solution`)
+            .notConsumable(`1x ${tree}_mushroom`)
+            .notConsumable(`1x undergarden:deepsoil`)
+            .inputFluids(['gtceu:nutrient_solution 25', 'gtceu:undergarden_smog 100'])
+            .itemOutputs(`24x ${tree}_mushroom_stem`, `6x ${tree}_mushroom_cap`)
+            .chancedOutput(`12x ${tree}_mushroom_stem`, 5000, 500)
+            .chancedOutput(`3x ${tree}_mushroom_cap`, 5000, 500)
+            .chancedOutput(`4x ${tree}_mushroom`, 500, 0)
+            .duration(100)
+            .EUt(GTValues.VA[GTValues.HV] / 2)
+    })
 })


### PR DESCRIPTION
Adds Arboreal Growth Facility recipes for the Undergarden Fungi. One of them is required for the better Rune of Earth recipe in the Essence Reactor.

I followed the tradition of using the air of the dim, but I also saw that blood mushroom uses Sulfur Trioxide. So it could be changed if requested.