### PR TITLE
Add ITNT recipe for Mechanical Entropinnyum

### DIFF
--- a/overrides/kubejs/server_scripts/Recipes/Cosmic_Frontiers.js
+++ b/overrides/kubejs/server_scripts/Recipes/Cosmic_Frontiers.js
@@ -442,9 +442,15 @@ ServerEvents.recipes(event => {
               .outputFluids(Fluid.of('gtceu:potent_mana', 6000))
               .duration(2100)
               .EUt(GTValues.VA[GTValues.EV]);
-       event.recipes.gtceu.mana_simulator('cosmiccore:mechanical_entropinnyum')
+       event.recipes.gtceu.mana_simulator('cosmiccore:mechanical_entropinnyum_tnt')
               .notConsumable('kubejs:mechanical_entropinnyum')
               .itemInputs('4x minecraft:tnt')
+              .outputFluids(Fluid.of('gtceu:potent_mana', 6000))
+              .duration(120)
+              .EUt(GTValues.VA[GTValues.EV]);
+       event.recipes.gtceu.mana_simulator('cosmiccore:mechanical_entropinnyum_itnt')
+              .notConsumable('kubejs:mechanical_entropinnyum')
+              .itemInputs('1x gtceu:industrial_tnt')
               .outputFluids(Fluid.of('gtceu:potent_mana', 6000))
               .duration(120)
               .EUt(GTValues.VA[GTValues.EV]);


### PR DESCRIPTION
1 ITNT instead of 4 TNT for the same amount of mana generated. 
ITNT has the added cost of Nitric Acid and a base HV recipe compared to TNT's base LV recipe with Sulfuric Acid.

![image](https://github.com/user-attachments/assets/fb649b21-0693-4051-b734-0d21a69bf2ee)
