### PR TITLE
Add circuit to h2o2 recipe

### DIFF
--- a/overrides/kubejs/server_scripts/Recipes/Chains/PlatLine.js
+++ b/overrides/kubejs/server_scripts/Recipes/Chains/PlatLine.js
@@ -64,6 +64,7 @@ ServerEvents.recipes(event => {
         .inputFluids('gtceu:oxygen 6000')
         .outputFluids('gtceu:hydrogen_peroxide 2000')
         .outputFluids('gtceu:carbon_dioxide 1000')
+        .circuit(7)
         .duration(160)
         .EUt(GTValues.VA[GTValues.HV]);
     event.recipes.gtceu.chemical_reactor('hydrazine_craft')


### PR DESCRIPTION
Adds a circuit to Methane to h2o2 recipe so it is also doable in an LCR.
![image](https://github.com/user-attachments/assets/5ff53b9b-3fa5-4270-b455-834e9e750795)

Closes #467 