### PR TITLE
Add 1 Step AE2 Cable Coloring

### DIFF
--- a/overrides/kubejs/server_scripts/Recipes/Ae2_Mods.js
+++ b/overrides/kubejs/server_scripts/Recipes/Ae2_Mods.js
@@ -886,19 +886,55 @@ ServerEvents.recipes(event => {
     } else {
       polymer = 'gtceu:polybenzimidazole_foil'
     }
+    const dyeColors = [
+    'white',
+    'light_gray',
+    'gray',
+    'black',
+    'brown',
+    'red',
+    'orange',
+    'yellow',
+    'lime',
+    'green',
+    'cyan',
+    'light_blue',
+    'blue',
+    'purple',
+    'magenta',
+    'pink'
+  ]
 
+    dyeColors.forEach(dye => {
+      event.recipes.gtceu.laminator(`smart_cable_${tier}_${dye}`)
+        .itemInputs([`gtceu:${tier}_single_cable`, `${polymer}`])
+        .inputFluids([`gtceu:${fluids} 144`, `gtceu:${dye}_dye 288`])
+        .itemOutputs(`${output}x ae2:${dye}_smart_cable`)
+        .circuit(2)
+        .duration(100)
+        .EUt(euType);
+      event.recipes.gtceu.laminator(`dense_cable_${tier}_${dye}`)
+      .itemInputs([`gtceu:${tier}_quadruple_cable`, `16x ${polymer}`])
+      .inputFluids([`gtceu:${fluids} 144`, `gtceu:${dye}_dye 2304`])
+      .itemOutputs(`${output}x ae2:${dye}_smart_dense_cable`)
+      .duration(100)
+      .circuit(2)
+      .EUt(euType);
+    });
 
     event.recipes.gtceu.laminator(`smart_cable_${tier}`)
       .itemInputs([`gtceu:${tier}_single_cable`, `${polymer}`])
       .inputFluids(`gtceu:${fluids} 144`)
       .itemOutputs(`${output}x ae2:fluix_smart_cable`)
       .duration(100)
+      .circuit(1)
       .EUt(euType);
     event.recipes.gtceu.laminator(`dense_cable_${tier}`)
       .itemInputs([`gtceu:${tier}_quadruple_cable`, `16x ${polymer}`])
       .inputFluids(`gtceu:${fluids} 144`)
       .itemOutputs(`${output}x ae2:fluix_smart_dense_cable`)
       .duration(100)
+      .circuit(1)
       .EUt(euType);
     event.recipes.gtceu.cutter(`ae2:${tier}_cable_anchor`)
       .itemInputs(`gtceu:${fluids}_bolt`)

--- a/overrides/kubejs/startup_scripts/Machines/RecipeTypes.js
+++ b/overrides/kubejs/startup_scripts/Machines/RecipeTypes.js
@@ -21,7 +21,7 @@ GTCEuStartupEvents.registry('gtceu:recipe_type', event => {
 
     event.create('laminator')
         .category('frontiers')
-        .setMaxIOSize(2, 2, 2, 0) //Max Item in, max item out, max fluid in, max fluid out (in slots)
+        .setMaxIOSize(3, 2, 2, 0) //Max Item in, max item out, max fluid in, max fluid out (in slots)
         .setSlotOverlay(false, false, GuiTextures.NEUTRAL_MATTER_OVERLAY)
         .setEUIO('in')
         .setProgressBar(GuiTextures.PROGRESS_BAR_ARROW, FillDirection.LEFT_TO_RIGHT)


### PR DESCRIPTION
Adds recipes to skip the shapeless coloring recipe for coloring AE2 smart cables.
Also adds circuits for the recipes so they don't clash. (**Breaking Change**)
I haven't seen any issues so far from taking a glance at random dyed cable recipes, but a second pair of eyes would be nice.

Dyed Cables:
<img width="768" height="406" alt="image" src="https://github.com/user-attachments/assets/30dd0483-6619-459f-bbe8-20afcf122ec4" />
<img width="790" height="404" alt="image" src="https://github.com/user-attachments/assets/7e85176c-cd2f-467e-99ac-ff98c94a5ca2" />

Fluix Cables:
<img width="751" height="393" alt="image" src="https://github.com/user-attachments/assets/4dd470de-0b63-4708-bc01-014f5d2d7fe9" />
<img width="782" height="418" alt="image" src="https://github.com/user-attachments/assets/74108328-a6f1-4431-a6b4-9d6c8f147e3a" />


