### PR TITLE
Gregify Travel Anchors

### DIFF
--- a/overrides/kubejs/server_scripts/Recipes/Travel_Anchors.js
+++ b/overrides/kubejs/server_scripts/Recipes/Travel_Anchors.js
@@ -1,0 +1,32 @@
+ServerEvents.recipes(event => {
+    event.remove({id: 'travelanchors:travel_staff'})
+    event.remove({id: 'travelanchors:travel_anchor'})
+    
+    event.shaped( 'travelanchors:travel_anchor',[
+        'ADA',
+        'BCB',
+        'ADA'
+    ], {
+        A: 'gtceu:steel_plate',
+        B: 'gtceu:runed_steel_foil',
+        D: '#gtceu:circuits/lv',
+        C: 'gtceu:ender_pearl_block'
+    })
+    event.recipes.gtceu.assembler('travel_anchor')
+    .itemInputs(['4x gtceu:steel_plate', '2x gtceu:runed_steel_foil', '2x #gtceu:circuits/lv', 'gtceu:ender_pearl_block'])
+    .itemOutputs('travelanchors:travel_anchor')
+    .duration(140)
+    .EUt(GTValues.VA[GTValues.LV])
+
+    event.shaped( 'travelanchors:travel_staff',[
+        ' SC',
+        'WRS',
+        'RD '
+    ], {
+        S: 'gtceu:runed_steel_screw',
+        C: 'gtceu:lv_field_generator',
+        R: 'gtceu:long_manasteel_rod',
+        W: '#gtceu:tools/crafting_wrenches',
+        D: '#gtceu:tools/crafting_screwdrivers'
+    })
+})


### PR DESCRIPTION
Gregifies the recipes for the Staff of Traveling and Travel Anchors in the pack.
They are currently set to early LV for anchors and late LV for the staff.

<img width="615" height="283" alt="image" src="https://github.com/user-attachments/assets/509d75f3-f421-4da7-95d6-adc1b93e2eb0" />
<img width="744" height="519" alt="image" src="https://github.com/user-attachments/assets/7ab24aa6-ee4e-4588-8c1f-3c75a1ebe05b" />

<img width="599" height="274" alt="image" src="https://github.com/user-attachments/assets/fc5242c6-dea6-40ce-a2dd-ea488b3debe5" />
