### PR TITLE
Remove Quartz Geode world generation (fr this time?)

### DIFF
--- a/overrides/kubejs/data/malum/worldgen/configured_feature/quartz_geode.json
+++ b/overrides/kubejs/data/malum/worldgen/configured_feature/quartz_geode.json
@@ -1,0 +1,4 @@
+{
+    "type": "minecraft:no_op",
+    "config": {}
+}


### PR DESCRIPTION
Removed the ability for the Quartz Geode to generate as it is no longer configured with this change.