### PR TITLE
fixing apoth 2 electric boogaloo

### DIFF
--- a/overrides/config/apotheosis/adventure.cfg
+++ b/overrides/config/apotheosis/adventure.cfg
@@ -10,6 +10,9 @@ affixes {
         minecraft:iron_sword|sword
         cosmiccore:trinavine_meld_tool|pickaxe
         minecraft:shulker_shell|none
+        gtceu:manasteel_pickaxe|pickaxe
+        gtceu:elementium_pickaxe|pickaxe
+        gtceu:terrasteel_pickaxe|pickaxe
         gtceu:aluminium_pickaxe|pickaxe
         gtceu:iron_pickaxe|pickaxe
         gtceu:titanium_pickaxe|pickaxe
@@ -33,6 +36,9 @@ affixes {
         gtceu:red_steel_pickaxe|pickaxe
         gtceu:blue_steel_pickaxe|pickaxe
         gtceu:hsse_pickaxe|pickaxe
+        gtceu:manasteel_hammer|pickaxe
+        gtceu:elementium_hammer|pickaxe
+        gtceu:terrasteel_hammer|pickaxe
         gtceu:aluminium_hammer|pickaxe
         gtceu:iron_hammer|pickaxe
         gtceu:titanium_hammer|pickaxe
@@ -56,6 +62,9 @@ affixes {
         gtceu:red_steel_hammer|pickaxe
         gtceu:blue_steel_hammer|pickaxe
         gtceu:hsse_hammer|pickaxe
+        gtceu:manasteel_mining_hammer|pickaxe
+        gtceu:elementium_mining_hammer|pickaxe
+        gtceu:terrasteel_mining_hammer|pickaxe
         gtceu:aluminium_mining_hammer|pickaxe
         gtceu:iron_mining_hammer|pickaxe
         gtceu:titanium_mining_hammer|pickaxe
@@ -79,6 +88,9 @@ affixes {
         gtceu:red_steel_mining_hammer|pickaxe
         gtceu:blue_steel_mining_hammer|pickaxe
         gtceu:hsse_mining_hammer|pickaxe
+        gtceu:lv_manasteel_drill|pickaxe
+        gtceu:lv_elementium_drill|pickaxe
+        gtceu:lv_terrasteel_drill|pickaxe
         gtceu:lv_aluminium_drill|pickaxe
         gtceu:lv_iron_drill|pickaxe
         gtceu:lv_titanium_drill|pickaxe
@@ -102,6 +114,9 @@ affixes {
         gtceu:lv_red_steel_drill|pickaxe
         gtceu:lv_blue_steel_drill|pickaxe
         gtceu:lv_hsse_drill|pickaxe
+        gtceu:mv_manasteel_drill|pickaxe
+        gtceu:mv_elementium_drill|pickaxe
+        gtceu:mv_terrasteel_drill|pickaxe
         gtceu:mv_aluminium_drill|pickaxe
         gtceu:mv_iron_drill|pickaxe
         gtceu:mv_titanium_drill|pickaxe
@@ -125,6 +140,9 @@ affixes {
         gtceu:mv_red_steel_drill|pickaxe
         gtceu:mv_blue_steel_drill|pickaxe
         gtceu:mv_hsse_drill|pickaxe
+        gtceu:hv_manasteel_drill|pickaxe
+        gtceu:hv_elementium_drill|pickaxe
+        gtceu:hv_terrasteel_drill|pickaxe
         gtceu:hv_aluminium_drill|pickaxe
         gtceu:hv_iron_drill|pickaxe
         gtceu:hv_titanium_drill|pickaxe
@@ -148,6 +166,9 @@ affixes {
         gtceu:hv_red_steel_drill|pickaxe
         gtceu:hv_blue_steel_drill|pickaxe
         gtceu:hv_hsse_drill|pickaxe
+        gtceu:ev_manasteel_drill|pickaxe
+        gtceu:ev_elementium_drill|pickaxe
+        gtceu:ev_terrasteel_drill|pickaxe
         gtceu:ev_aluminium_drill|pickaxe
         gtceu:ev_iron_drill|pickaxe
         gtceu:ev_titanium_drill|pickaxe
@@ -171,6 +192,9 @@ affixes {
         gtceu:ev_red_steel_drill|pickaxe
         gtceu:ev_blue_steel_drill|pickaxe
         gtceu:ev_hsse_drill|pickaxe
+        gtceu:iv_manasteel_drill|pickaxe
+        gtceu:iv_elementium_drill|pickaxe
+        gtceu:iv_terrasteel_drill|pickaxe
         gtceu:iv_aluminium_drill|pickaxe
         gtceu:iv_iron_drill|pickaxe
         gtceu:iv_titanium_drill|pickaxe
@@ -194,6 +218,9 @@ affixes {
         gtceu:iv_red_steel_drill|pickaxe
         gtceu:iv_blue_steel_drill|pickaxe
         gtceu:iv_hsse_drill|pickaxe
+        gtceu:manasteel_wrench|pickaxe
+        gtceu:elementium_wrench|pickaxe
+        gtceu:terrasteel_wrench|pickaxe
         gtceu:aluminium_wrench|pickaxe
         gtceu:iron_wrench|pickaxe
         gtceu:titanium_wrench|pickaxe
@@ -217,6 +244,9 @@ affixes {
         gtceu:red_steel_wrench|pickaxe
         gtceu:blue_steel_wrench|pickaxe
         gtceu:hsse_wrench|pickaxe
+        gtceu:lv_manasteel_wrench|pickaxe
+        gtceu:lv_elementium_wrench|pickaxe
+        gtceu:lv_terrasteel_wrench|pickaxe
         gtceu:lv_aluminium_wrench|pickaxe
         gtceu:lv_iron_wrench|pickaxe
         gtceu:lv_titanium_wrench|pickaxe
@@ -240,6 +270,9 @@ affixes {
         gtceu:lv_red_steel_wrench|pickaxe
         gtceu:lv_blue_steel_wrench|pickaxe
         gtceu:lv_hsse_wrench|pickaxe
+        gtceu:hv_manasteel_wrench|pickaxe
+        gtceu:hv_elementium_wrench|pickaxe
+        gtceu:hv_terrasteel_wrench|pickaxe
         gtceu:hv_aluminium_wrench|pickaxe
         gtceu:hv_iron_wrench|pickaxe
         gtceu:hv_titanium_wrench|pickaxe
@@ -263,6 +296,9 @@ affixes {
         gtceu:hv_red_steel_wrench|pickaxe
         gtceu:hv_blue_steel_wrench|pickaxe
         gtceu:hv_hsse_wrench|pickaxe
+        gtceu:iv_manasteel_wrench|pickaxe
+        gtceu:iv_elementium_wrench|pickaxe
+        gtceu:iv_terrasteel_wrench|pickaxe
         gtceu:iv_aluminium_wrench|pickaxe
         gtceu:iv_iron_wrench|pickaxe
         gtceu:iv_titanium_wrench|pickaxe
@@ -286,6 +322,9 @@ affixes {
         gtceu:iv_red_steel_wrench|pickaxe
         gtceu:iv_blue_steel_wrench|pickaxe
         gtceu:iv_hsse_wrench|pickaxe
+        gtceu:manasteel_wire_cutter|pickaxe
+        gtceu:elementium_wire_cutter|pickaxe
+        gtceu:terrasteel_wire_cutter|pickaxe
         gtceu:aluminium_wire_cutter|pickaxe
         gtceu:iron_wire_cutter|pickaxe
         gtceu:titanium_wire_cutter|pickaxe
@@ -309,6 +348,87 @@ affixes {
         gtceu:red_steel_wire_cutter|pickaxe
         gtceu:blue_steel_wire_cutter|pickaxe
         gtceu:hsse_wire_cutter|pickaxe
+        gtceu:lv_manasteel_wire_cutter|pickaxe
+        gtceu:lv_elementium_wire_cutter|pickaxe
+        gtceu:lv_terrasteel_wire_cutter|pickaxe
+        gtceu:lv_aluminium_wire_cutter|pickaxe
+        gtceu:lv_iron_wire_cutter|pickaxe
+        gtceu:lv_titanium_wire_cutter|pickaxe
+        gtceu:lv_neutronium_wire_cutter|pickaxe
+        gtceu:lv_duranium_wire_cutter|pickaxe
+        gtceu:lv_bronze_wire_cutter|pickaxe
+        gtceu:lv_diamond_wire_cutter|pickaxe
+        gtceu:lv_invar_wire_cutter|pickaxe
+        gtceu:lv_starling_silver_wire_cutter|pickaxe
+        gtceu:lv_rose_gold_wire_cutter|pickaxe
+        gtceu:lv_stainless_steel_wire_cutter|pickaxe
+        gtceu:lv_steel_wire_cutter|pickaxe
+        gtceu:lv_ultimet_wire_cutter|pickaxe
+        gtceu:lv_wrought_iron_wire_cutter|pickaxe
+        gtceu:lv_tungsten_carbide_wire_cutter|pickaxe
+        gtceu:lv_damascus_steel_wire_cutter|pickaxe
+        gtceu:lv_tungsten_steel_wire_cutter|pickaxe
+        gtceu:lv_cobalt_brass_wire_cutter|pickaxe
+        gtceu:lv_vanadium_steel_wire_cutter|pickaxe
+        gtceu:lv_naquadah_alloy_wire_cutter|pickaxe
+        gtceu:lv_red_steel_wire_cutter|pickaxe
+        gtceu:lv_blue_steel_wire_cutter|pickaxe
+        gtceu:lv_hsse_wire_cutter|pickaxe
+        gtceu:hv_manasteel_wire_cutter|pickaxe
+        gtceu:hv_elementium_wire_cutter|pickaxe
+        gtceu:hv_terrasteel_wire_cutter|pickaxe
+        gtceu:hv_aluminium_wire_cutter|pickaxe
+        gtceu:hv_iron_wire_cutter|pickaxe
+        gtceu:hv_titanium_wire_cutter|pickaxe
+        gtceu:hv_neutronium_wire_cutter|pickaxe
+        gtceu:hv_duranium_wire_cutter|pickaxe
+        gtceu:hv_bronze_wire_cutter|pickaxe
+        gtceu:hv_diamond_wire_cutter|pickaxe
+        gtceu:hv_invar_wire_cutter|pickaxe
+        gtceu:hv_starling_silver_wire_cutter|pickaxe
+        gtceu:hv_rose_gold_wire_cutter|pickaxe
+        gtceu:hv_stainless_steel_wire_cutter|pickaxe
+        gtceu:hv_steel_wire_cutter|pickaxe
+        gtceu:hv_ultimet_wire_cutter|pickaxe
+        gtceu:hv_wrought_iron_wire_cutter|pickaxe
+        gtceu:hv_tungsten_carbide_wire_cutter|pickaxe
+        gtceu:hv_damascus_steel_wire_cutter|pickaxe
+        gtceu:hv_tungsten_steel_wire_cutter|pickaxe
+        gtceu:hv_cobalt_brass_wire_cutter|pickaxe
+        gtceu:hv_vanadium_steel_wire_cutter|pickaxe
+        gtceu:hv_naquadah_alloy_wire_cutter|pickaxe
+        gtceu:hv_red_steel_wire_cutter|pickaxe
+        gtceu:hv_blue_steel_wire_cutter|pickaxe
+        gtceu:hv_hsse_wire_cutter|pickaxe
+        gtceu:iv_manasteel_wire_cutter|pickaxe
+        gtceu:iv_elementium_wire_cutter|pickaxe
+        gtceu:iv_terrasteel_wire_cutter|pickaxe
+        gtceu:iv_aluminium_wire_cutter|pickaxe
+        gtceu:iv_iron_wire_cutter|pickaxe
+        gtceu:iv_titanium_wire_cutter|pickaxe
+        gtceu:iv_neutronium_wire_cutter|pickaxe
+        gtceu:iv_duranium_wire_cutter|pickaxe
+        gtceu:iv_bronze_wire_cutter|pickaxe
+        gtceu:iv_diamond_wire_cutter|pickaxe
+        gtceu:iv_invar_wire_cutter|pickaxe
+        gtceu:iv_starling_silver_wire_cutter|pickaxe
+        gtceu:iv_rose_gold_wire_cutter|pickaxe
+        gtceu:iv_stainless_steel_wire_cutter|pickaxe
+        gtceu:iv_steel_wire_cutter|pickaxe
+        gtceu:iv_ultimet_wire_cutter|pickaxe
+        gtceu:iv_wrought_iron_wire_cutter|pickaxe
+        gtceu:iv_tungsten_carbide_wire_cutter|pickaxe
+        gtceu:iv_damascus_steel_wire_cutter|pickaxe
+        gtceu:iv_tungsten_steel_wire_cutter|pickaxe
+        gtceu:iv_cobalt_brass_wire_cutter|pickaxe
+        gtceu:iv_vanadium_steel_wire_cutter|pickaxe
+        gtceu:iv_naquadah_alloy_wire_cutter|pickaxe
+        gtceu:iv_red_steel_wire_cutter|pickaxe
+        gtceu:iv_blue_steel_wire_cutter|pickaxe
+        gtceu:iv_hsse_wire_cutter|pickaxe
+        gtceu:manasteel_shovel|shovel
+        gtceu:elementium_shovel|shovel
+        gtceu:terrasteel_shovel|shovel
         gtceu:aluminium_shovel|shovel
         gtceu:iron_shovel|shovel
         gtceu:titanium_shovel|shovel
@@ -332,6 +452,9 @@ affixes {
         gtceu:red_steel_shovel|shovel
         gtceu:blue_steel_shovel|shovel
         gtceu:hsse_shovel|shovel
+        gtceu:manasteel_spade|shovel
+        gtceu:elementium_spade|shovel
+        gtceu:terrasteel_spade|shovel
         gtceu:aluminium_spade|shovel
         gtceu:iron_spade|shovel
         gtceu:titanium_spade|shovel


### PR DESCRIPTION
brought back manasteel, elementium and terrasteel tool materials under pickaxe affixes
brought back electric wirecutters there too