### PR TITLE
make ender tanks/chests need GT items instead of ender pearls, also adds tooltips

### DIFF
--- a/overrides/config/enderchests.toml
+++ b/overrides/config/enderchests.toml
@@ -12,9 +12,9 @@ full_stack_linking = true
 	#Items used to make the chests team chests
 	team = ["tag|forge:gems/emerald"]
 	#Items that upgrade storage capacity by 3
-	small_capacity = ["minecraft:ender_pearl"]
+	small_capacity = ["gtceu:lv_field_generator"]
 	#Items that upgrade storage capacity by 9
-	large_capacity = ["minecraft:ender_eye"]
+	large_capacity = ["gtceu:mv_field_generator"]
 	#Items that upgrade storage capacity by 3
 	#Each item can only be use once per chest
 	small_capacity_singleuse = []

--- a/overrides/config/endertanks.toml
+++ b/overrides/config/endertanks.toml
@@ -12,11 +12,11 @@ full_stack_linking = true
 	#Items used to make the tanks team tanks
 	team = ["tag|forge:gems/emerald"]
 	#Items that apply a small storage capacity upgrade
-	small_capacity = ["minecraft:ender_pearl"]
+	small_capacity = ["gtceu:lv_field_generator"]
 	#Items that apply a large storage capacity upgrade
-	large_capacity = ["minecraft:ender_eye"]
+	large_capacity = ["gtceu:mv_field_generator"]
 	#Items that are used to increase the tanks internal transfer pump
-	pump = ["minecraft:piston"]
+	pump = ["gtceu:lv_electric_piston"]
 	#Items that apply a small storage capacity upgrade
 	#Each item can only be use once per tank
 	small_capacity_singleuse = []
@@ -44,7 +44,7 @@ full_stack_linking = true
 	small_capacity_upgrade = 8
 	#Capacity increased by large capacity upgrade items
 	#Range: 4 ~ 32
-	large_capacity_upgrade = 16
+	large_capacity_upgrade = 32
 
 [access_settings]
 	#Enables the usage of public tanks, if disabled tanks must be upgraded before use

--- a/overrides/kubejs/client_scripts/ToolTips.js
+++ b/overrides/kubejs/client_scripts/ToolTips.js
@@ -339,6 +339,24 @@ ItemEvents.tooltip(event => {
   event.addAdvanced('legendarysurvivaloverhaul:purified_water_bottle', (item, advanced, text) => {
     text.add(1, Text.of('Recipes Do Not Work In Iron Furnaces').red())
   })
+  //ender tanks/chests
+  event.addAdvanced('endertanks:ender_tank', (item, advanced, text) => {
+    text.add(1, Text.of('Requires GT Components To Upgrade').blue().italic())
+    if (event.isShift()) {
+    text.add(2, [Text.of('Capacity: ').aqua(), Text.of('LV Field Generator, 8B Per').gray(), Text.of(' Or ').gold(), Text.of('MV Field Generator, 32B Per, Max').gray().gray(), Text.of(' 256B ').gold()])
+    text.add(3, [Text.of('Pump Speed: ').aqua(), Text.of('LV Electric Piston, 1B Per, Max').gray(), Text.of(' 4B ').gold()])
+    } else {
+      text.add(2, [Text.of('Hold ').gold(), Text.of('Shift ').yellow(), Text.of('to see more info.').gold()])
+    }
+  })
+  event.addAdvanced('enderchests:ender_chest', (item, advanced, text) => {
+    text.add(1, Text.of('Requires GT Components To Upgrade').blue().italic())
+    if (event.isShift()) {
+    text.add(2, [Text.of('Inventory Slots: ').aqua(), Text.of('LV Field Generator, 3 Slots Per').gray(), Text.of(' Or ').gold(), Text.of('MV Field Generator, 9 Slots Per, Max').gray(), Text.of(' 27 ').gold()])
+    } else {
+      text.add(2, [Text.of('Hold ').gold(), Text.of('Shift ').yellow(), Text.of('to see more info.').gold()])
+    }
+  })
 
 })
 

--- a/overrides/kubejs/client_scripts/ToolTips.js
+++ b/overrides/kubejs/client_scripts/ToolTips.js
@@ -341,20 +341,18 @@ ItemEvents.tooltip(event => {
   })
   //ender tanks/chests
   event.addAdvanced('endertanks:ender_tank', (item, advanced, text) => {
-    text.add(1, Text.of('Requires GT Components To Upgrade').blue().italic())
     if (event.isShift()) {
     text.add(2, [Text.of('Capacity: ').aqua(), Text.of('LV Field Generator, 8B Per').gray(), Text.of(' Or ').gold(), Text.of('MV Field Generator, 32B Per, Max').gray().gray(), Text.of(' 256B ').gold()])
     text.add(3, [Text.of('Pump Speed: ').aqua(), Text.of('LV Electric Piston, 1B Per, Max').gray(), Text.of(' 4B ').gold()])
     } else {
-      text.add(2, [Text.of('Hold ').gold(), Text.of('Shift ').yellow(), Text.of('to see more info.').gold()])
+      text.add(2, [Text.of('Can be upgraded, Hold ').gold(), Text.of('Shift ').yellow(), Text.of('to see more info.').gold()])
     }
   })
   event.addAdvanced('enderchests:ender_chest', (item, advanced, text) => {
-    text.add(1, Text.of('Requires GT Components To Upgrade').blue().italic())
     if (event.isShift()) {
     text.add(2, [Text.of('Inventory Slots: ').aqua(), Text.of('LV Field Generator, 3 Slots Per').gray(), Text.of(' Or ').gold(), Text.of('MV Field Generator, 9 Slots Per, Max').gray(), Text.of(' 27 ').gold()])
     } else {
-      text.add(2, [Text.of('Hold ').gold(), Text.of('Shift ').yellow(), Text.of('to see more info.').gold()])
+      text.add(2, [Text.of('Can be upgraded, Hold ').gold(), Text.of('Shift ').yellow(), Text.of('to see more info.').gold()])
     }
   })
 


### PR DESCRIPTION
i was going to do cells/drums/pumps for the tanks but they dont work, likely cause of trying to shift right click a fluid inventory

<img width="567" height="256" alt="image" src="https://github.com/user-attachments/assets/268959fd-160f-47d7-b41d-7ceda4eba928" />
<img width="1216" height="295" alt="image" src="https://github.com/user-attachments/assets/c1a6918d-6b8f-49a6-82b7-2c871923a850" />
<img width="1288" height="291" alt="image" src="https://github.com/user-attachments/assets/38c89e80-31f4-4606-855b-07e71c0b2fef" />

ima hope this way of uploading an image works

