### PR TITLE
add GT machine support for food recipes

### DIFF
--- a/overrides/kubejs/server_scripts/Recipes/port_food_recipes.js
+++ b/overrides/kubejs/server_scripts/Recipes/port_food_recipes.js
@@ -1,0 +1,559 @@
+
+
+ServerEvents.recipes(event => {
+
+    //keep a list of what we've added to prevent duplicate entries
+    let addedRecipes = [];
+
+    //blacklist (original / source) recipes that we don't want to auto-port, for whatever reason
+    //note that this is *not* regex, but supports $ for string-ending as this normally performs a startsWith
+    let recipeBlacklist = [
+        //mixer stuff that isn't food-related or has duplicates (e.g. heated vs non-heated tea)
+        "createlowheated:mixing/chocolate$",
+        "create:mixing/tea",
+        "create:mixing/lava_from_cobble",
+        "create:mixing/mud_by_mixing",
+
+        //slicer stuff
+        "farmersdelight:cutting/warped_stem",
+        "farmersdelight:cutting/gravel",
+        "farmersdelight:cutting/stone",
+        "farmersdelight:cutting/deepslate",
+        "farmersdelight:cutting/clay",
+        "farmersdelight:cutting/quartz",
+        "farmersdelight:cutting/amethyst_block",
+        "delightful:cutting/grass",
+        "delightful:cutting/tall_grass",
+        "delightful:cutting/sandy_shrub",
+        "nethersdelight:cutting/propelplant_cane", //TODO: should this be removed from cutting board as well?
+        "seeddelight:cutting/pinecone",
+        "vegandelight:cutting/feather",
+        "delightful:integration/ars_nouveau/cutting/magebloom", //TODO: obsolete this because of volt's PR to remove the base recipe
+
+        //cul assem stuff
+        "farmersdelight:cooking/cooked/clawster",
+        "farmersdelight:cooking/cooked/crab",
+        "farmersdelight:cooking/cooked/shrimp",
+        "vegandelight:cooking/salt",
+        "vegandelight:cooking/ink_sac",
+
+        //just.. the whole mod
+        "supplementaries:",
+        "malum:"
+    ];
+
+    //default predicate for blacklisting recipes; automatically implements the recipeBlacklist above
+    //returning true will cause the recipe to be blacklisted / ignored
+    let defaultRecipeBlacklistPredicate = (type, origRecipeName, newRecipeName, itemIngredients, fluidIngredients, itemResults, fluidResults) => {
+        var loopReturn = false; //we're gunna reuse this
+        recipeBlacklist.forEach(x=> {
+            //$ is typically regex-syntax for 'end of string' but doing full regex processing is a waste
+            if (x.endsWith("$") ? origRecipeName == x.substring(0, x.length - 1) : origRecipeName.startsWith(x)) {
+                loopReturn = true;
+                return;
+            }
+        });
+        if (loopReturn == true) {
+            return true;
+        }
+
+        var stripOutWithItemResults = [
+            "dye",
+            "stripped",
+            "planks",
+            "coral", //this is.... it technically makes foods? unsure on this one
+            "leather",
+            "brick"
+        ];
+
+        //strip out by result wildcard includes()
+        loopReturn = false;
+        if (itemResults && itemResults.length > 0
+            && itemResults.filter(x=> {
+            stripOutWithItemResults.forEach((so) => {
+                if (x.item.includes(so)) {
+                    loopReturn = true;
+                    return;
+                }
+            });
+            if (loopReturn) {
+                return true;
+            }
+        })
+            .length > 0
+        ) {
+            return true;
+        }
+
+        return false;
+    }
+
+    //default function that will be passed multiple times since it will handle most things
+    let defaultAutoportFunction = (type, origRecipeName, newRecipeName, itemIngredients, fluidIngredients, itemResults, fluidResults) => {
+
+        let ret = {
+            machine: "culinary_assembler",
+            eu: GTValues.VA[GTValues.LV],
+            duration: 40,
+            additionalIngredients: [],
+            additionalFluids: []
+        }
+
+        if (type == "vintagedelight:fermenting") {
+            //fermenting takes a while
+            ret.duration = 400;
+            //gt fermenter only has 1 input/output, but we'll use it where we can
+            if (itemIngredients != null && itemIngredients.length < 2 && fluidIngredients.length < 2 && itemResults.length < 2 && fluidResults.length < 2) {
+                ret.machine = "fermenter";
+            }
+        }
+        else if (type == "barbequesdelight:grilling") {
+            //i just find the thought of this kinda funny lol, could change it to fryer and be boring i guess
+            ret.machine = "arc_furnace";
+        }
+
+        if (origRecipeName.includes("fried_")) {
+            if ((itemIngredients == null || itemIngredients.length < 7) && (fluidIngredients == null || fluidIngredients.length < 2)) {
+                ret.machine = "fryer";
+            }
+            if (fluidIngredients && fluidIngredients.length < 1) {
+                ret.additionalFluids.push([{fluid: "gtceu:seed_oil", amount: 20}, {fluid: "gtceu:fish_oil", amount: 20}]);
+            }
+        }
+
+        //cul assem doesn't support fluid outputs
+        if (fluidResults && fluidResults.length > 0)
+        {
+            ret.machine = "mixer";
+        }
+
+        if (itemIngredients != null && itemIngredients.length > 0) {
+            //maybe later
+        }
+
+        return ret;
+    }
+
+    //debug recipe
+    //    event.recipes.gtceu.mixer("frontiers:debug_gtceu_mixer_mixeeeee")
+    //        //.itemInputs("[vegandelight:soymilk_bucket,vegandelight:soymilk_bottle],[#forge:salts,#forge:salt],minecraft:water_bucket,minecraft:bowl")
+    //        .itemInputs([["minecraft:stone", "minecraft:dirt"], ["minecraft:oak_log", "minecraft:spruce_log"], ['#forge:salts','#forge:salt']])
+    //        .itemOutputs("minecraft:dandelion")
+    //        .duration(40)
+    //        .EUt(GTValues.VA[GTValues.LV]);
+
+    //obsolete, just read the @farmersdelight cooking_pot lmao
+    //    console.log("Merging @create mixer (create:mixing) recipes into GT machines...");
+    //    event.forEachRecipe({ type: 'create:mixing' }, recipe => {
+    //        autoportRecipe(addedRecipes, event, recipe, defaultAutoportFunction, defaultRecipeBlacklistPredicate);
+    //    });
+
+
+    console.log("Merging @farmersdelight cutting_board (farmersdelight:cutting) recipes into GT slicer (gtceu:slicer)...");
+    event.forEachRecipe({ type: 'farmersdelight:cutting' }, recipe => {
+        autoportRecipe(addedRecipes, event, recipe, () => "slicer", defaultRecipeBlacklistPredicate); //all cutting recipes get thrown into the slicer
+    });
+
+    console.log("Merging @farmersdelight cooking_pot (farmersdelight:cooking) recipes into GT machines...");
+    event.forEachRecipe({ type: 'farmersdelight:cooking' }, recipe => {
+        autoportRecipe(addedRecipes, event, recipe, defaultAutoportFunction, defaultRecipeBlacklistPredicate);
+    });
+
+    console.log("Merging @vintagedelight fermenting_jar (farmersdelight:fermenting) recipes into GT machines...");
+    event.forEachRecipe({ type: 'vintagedelight:fermenting' }, recipe => {
+        autoportRecipe(addedRecipes, event, recipe, defaultAutoportFunction, defaultRecipeBlacklistPredicate);
+    });
+
+    //these are modular and thus don't qualify
+    //    console.log("Merging @cuisinedelight cuisine (cuisinedelight:cuisine) recipes into GT machines...");
+    //    event.forEachRecipe({ type: 'cuisinedelight:cuisine' }, recipe => {
+    //        autoportRecipe(addedRecipes, event, recipe, defaultAutoportFunction, defaultRecipeBlacklistPredicate);
+    //    });
+
+    console.log("Merging @barbequesdelight skewering (barbequesdelight:skewering) recipes into GT machines...");
+    event.forEachRecipe({ type: 'barbequesdelight:skewering' }, recipe => {
+        autoportRecipe(addedRecipes, event, recipe, defaultAutoportFunction, defaultRecipeBlacklistPredicate);
+    });
+
+    console.log("Merging @barbequesdelight grilling (barbequesdelight:grilling) recipes into GT machines...");
+    event.forEachRecipe({ type: 'barbequesdelight:grilling' }, recipe => {
+        autoportRecipe(addedRecipes, event, recipe, defaultAutoportFunction, defaultRecipeBlacklistPredicate);
+    });
+
+    //aging cheemse
+    //(producing cheese from curds isn't an actual recipe, it's a weird world-block interaction, so append it manually)
+    var newRecipe = event.recipes.gtceu["fermenter"]("frontiers:gtceu_age_cheese_curds")
+        newRecipe.itemOutputs("vintagedelight:cheese_wheel")
+        newRecipe.itemInputs("4x vintagedelight:cheese_curds")
+        .duration(4000)
+        .EUt(GTValues.VA[GTValues.LV]);
+});
+
+/// addedRecipes: all of the recipes that have been added thus far
+///         this is to ensure recipes don't take the same name and will also assign them a different circuit
+/// event: reference to the recipe ServerEvent
+/// recipe: the recipe from the ServerEvents
+/// machineSelectorFunction: function to determine which machine gets the recipe.
+///         the return format should be valid in the context of 'event.recipes.gtceu.[RETURN_VALUE]()'
+///         the function will run in the context of outputs (type: array) of the local autoportIngredientResultFilter() method
+///         the function will receive these parameters: 'type', 'origRecipeName', 'newRecipeName', 'itemIngredients', 'fluidIngredients', 'itemResults', 'fluidResults'
+///         to port the recipe to a specific machine without further logic, the function can be set to e.g.: () => "mixer"
+/// recipeBlacklistPredicate: predicate to determine whether or not a recipe should be skipped
+///         the predicate receives the same parameters: 'type', 'origRecipeName', 'newRecipeName', 'itemIngredients', 'fluidIngredients', 'itemResults', 'fluidResults'
+function autoportRecipe(addedRecipes, event, recipe, machineSelectorFunction, recipeBlacklistPredicate) {
+    //console.log(recipe.getClass());
+    //console.log(recipe.json);  //recipe.json = class com.google.gson.JsonObject
+    // recipe name format: create:mixing/mud_by_mixing[create:mixing]
+    var origRecipeName = recipe.toString().split("\\[")[0].toString();
+    var recipeName = origRecipeName.includes("\/") ? origRecipeName.split("\/") : origRecipeName.split("\:");
+    var origModRegistry = recipeName[0].includes("\:") ? recipeName[0].split("\:")[0] : recipeName[0];
+    recipeName = recipeName.slice(1); //drop the first part of the array before the /
+    recipeName = "frontiers:gtceu_" + origModRegistry + "_" + recipeName.join("_");
+
+    var type = recipe.json.get("type").toString().replaceAll("\"", "");
+
+    //this doesn't usually come up but certain things have an ingredient that's an array of tags,
+    //so I'm splitting them into multiple recipes which means this will happen and get a circuit
+    var idx = 2;
+    var useCircuit = false;
+    while (addedRecipes.includes(recipeName)) {
+        var potentialNewName = `${recipeName}_${idx}`;
+        if (!addedRecipes.includes(potentialNewName)) {
+            recipeName = potentialNewName;
+            useCircuit = true;
+            break;
+        }
+        idx++;
+    }
+
+    //console.log(`processing base recipe '${origRecipeName}' into '${recipeName}'...`);
+
+    //I hate indexing it this way; if someone knows how to do this better please do
+    //these should all be com.google.gson.JsonArray
+    var ingredients = recipe.json.has("ingredient") ? recipe.json.get("ingredient") : recipe.json.get("ingredients");
+    var toolIngredient = recipe.json.has("tool") ? recipe.json.get("tool") : recipe.json.get("tool");
+    var results = recipe.json.has("result") ? recipe.json.get("result")
+    : recipe.json.has("results") ? recipe.json.get("results")
+    : recipe.json.has("output") ? recipe.json.get("output")
+    : null;
+    var secondaryOutputs = recipe.json.has("secondaryOutput") ? recipe.json.get("secondaryOutput") : null;
+
+    if (ingredients != null && (ingredients.getClass == undefined || ingredients.getClass() == "class com.google.gson.JsonObject")) {
+        ingredients = JsonIO.parse(JsonIO.toString([ingredients]));
+        //console.log("transformed ingredients into array");
+    }
+    if (toolIngredient != null && (toolIngredient.getClass == undefined || toolIngredient.getClass() == "class com.google.gson.JsonObject")) {
+        toolIngredient = JsonIO.parse(JsonIO.toString([toolIngredient]));
+        //console.log("transformed ingredients into array");
+    }
+
+    if (results != null && (results.getClass == undefined || results.getClass() == "class com.google.gson.JsonObject")) {
+        results = JsonIO.parse(JsonIO.toString([results]));
+        //console.log("transformed results into array");
+    }
+    if (secondaryOutputs != null && (secondaryOutputs.getClass == undefined || secondaryOutputs.getClass() == "class com.google.gson.JsonObject")) {
+        secondaryOutputs = JsonIO.parse(JsonIO.toString([secondaryOutputs]));
+        //console.log("transformed secondaryOutputs into array");
+    }
+
+    //console.log("raw json ingredients:")
+    //console.log(ingredients)
+    if (toolIngredient != null) {
+        //console.log("raw tool ingredients:")
+        //console.log(toolIngredient)
+
+        if (toolIngredient.length > 0) {
+            ingredients.addAll(toolIngredient);
+            //console.log("appended tool ingredients to ingredients");
+        }
+    }
+    //console.log("raw json results:")
+    //console.log(results)
+    if (secondaryOutputs != null) {
+        //console.log("raw secondary outputs:")
+        //console.log(secondaryOutputs)
+
+        if (secondaryOutputs.length > 0) {
+            results.addAll(secondaryOutputs);
+            //console.log("appended secondary outputs to results");
+        }
+    }
+
+    var itemPredicate = x => (x.has("item") === true || x.has("tag") === true)
+        && x.has("fluid") === false && x.has("fluidTag") === false;
+    var fluidPredicate = x => (x.has("fluid") === true || x.has("fluidTag") === true)
+    && x.has("item") === false && x.has("tag") === false ;
+
+    //this can apparently be not only an object and array, but also an array of array
+    //e.g. [[{"item":"vegandelight:soymilk_bucket"},{"item":"vegandelight:soymilk_bottle"}], [{"tag":"forge:salts"},{"tag":"forge:salt"}], [{"item":"minecraft:water_bucket"}]]
+    var itemIngredients = autoportIngredientResultFilter(ingredients, itemPredicate);
+    var fluidIngredients = autoportIngredientResultFilter(ingredients, fluidPredicate);
+
+    //console.log("parsed json ingredients:")
+    //console.log(JsonIO.toString(itemIngredients));
+    //console.log("fluid ingredients:")
+    //console.log(JsonIO.toString(fluidIngredients));
+
+    var itemResults = autoportIngredientResultFilter(results, itemPredicate);
+    var fluidResults = autoportIngredientResultFilter(results, fluidPredicate);
+
+    //console.log("parsed json results:")
+    //console.log(JsonIO.toString(itemResults));
+    //console.log("fluid results:")
+    //console.log(JsonIO.toString(fluidResults));
+
+    var blacklisted = recipeBlacklistPredicate(type, origRecipeName, recipeName, itemIngredients, fluidIngredients, itemResults, fluidResults);
+    if (blacklisted == true) {
+        //console.log(`${origRecipeName} is blacklisted and will be ignored`)
+        return;
+    }
+
+    //we're gunna (potentially) do some recursive stuff because having an ingredient as an array of tags just doesn't work
+    //ingredients are an array
+    if (itemIngredients.forEach != null) {
+        //{result={"item":"vegandelight:tofu"}, ingredients=[[{"item":"vegandelight:soymilk_bucket"},{"item":"vegandelight:soymilk_bottle"}],
+        //[{"tag":"forge:salts"},{"tag":"forge:salt"}]], type="farmersdelight:cooking", experience=1.0, recipe_book_tab="meals", cookingtime=200}
+
+        var recursiveCall = false;
+
+        itemIngredients.forEach((ingredient) => {
+            //a specific ingredient is an array of ingredients
+            //works fine with items and fluids but not tags
+            if (ingredient.forEach != null) {
+                var tagEntries = ingredient.filter(x => x.tag != null);
+                var itemEntries = ingredient.filter(x => x.item != null);
+                if (tagEntries.length > 0) {
+                    tagEntries.forEach(tagEntry => {
+                        var newIngredients = itemIngredients.slice();
+                        newIngredients.splice(newIngredients.indexOf(ingredient), 1);
+                        newIngredients.push(tagEntry);
+
+                        if (recipe.json.has("ingredient")) {
+                            recipe.json.remove("ingredient");
+                        }
+                        if (recipe.json.has("ingredients")) {
+                            recipe.json.remove("ingredients");
+                        }
+                        recipe.json.add("ingredients", newIngredients);
+
+                        recursiveCall = true;
+
+                        //console.log("calling recursive recipe creation for tag " + JsonIO.toString(tagEntry));
+                        autoportRecipe(addedRecipes, event, recipe, machineSelectorFunction, recipeBlacklistPredicate);
+                    });
+
+                    //if we split out a tag recipe, we need to create a new recipe for all the non-tag items
+                    if (itemEntries.length > 0) {
+                        var newIngredients = itemIngredients.slice();
+                        newIngredients.splice(newIngredients.indexOf(ingredient), 1);
+                        newIngredients.push(itemEntries);
+
+                        if (recipe.json.has("ingredient")) {
+                            recipe.json.remove("ingredient");
+                        }
+                        if (recipe.json.has("ingredients")) {
+                            recipe.json.remove("ingredients");
+                        }
+                        recipe.json.add("ingredients", newIngredients);
+
+                        recursiveCall = true;
+
+                        //console.log("calling recursive recipe creation for items " + JsonIO.toString(itemEntries));
+                        autoportRecipe(addedRecipes, event, recipe, machineSelectorFunction, recipeBlacklistPredicate);
+                    }
+                }
+            }
+        });
+
+        if (recursiveCall == true) {
+                return;
+        }
+    }
+
+
+    //check for container requirements, such as bowls, and add them to the ingredients list
+    if (recipe.json.has("container")){
+        var container = recipe.json.get("container");
+        itemIngredients.push(container);
+        //console.log(`appended container '${container}'`);
+    }
+    //wow I... hate this
+    //tldr some recipes don't have a {container=} but need one, e.g. ratatouille
+    else if (type == "farmersdelight:cooking") {
+        if (itemResults.forEach && itemResults.length == 1) {
+            var outputItemStack = Item.of(itemResults[0]);
+            var outputItem = outputItemStack.getItem();
+            if (outputItem.hasCraftingRemainingItem() == true) {
+                var remainingItem = outputItem.getItem().getCraftingRemainingItem();
+                if (remainingItem != null) {
+                    itemIngredients.push(remainingItem);
+                }
+            }
+        }
+    }
+
+    //process the provided function -- a function is required, and a default one is available in this file
+    var machSelObj = machineSelectorFunction(type, origRecipeName, recipeName, itemIngredients, fluidIngredients, itemResults, fluidResults);
+
+    if (typeof(machSelObj) !== "object") {
+        if (typeof(machSelObj) !== "string") {
+            throw new Exception("only strings can be sent for the autoport machine, got: " + machSelObj);
+        }
+        machSelObj = {
+            machine: machSelObj,
+            eu: GTValues.VA[GTValues.LV],
+            duration: 40
+        }
+    }
+
+    //console.log(`machine selected: ${JsonIO.toString(machSelObj)}`)
+
+    if (machSelObj.additionalItems && machSelObj.additionalItems.length > 0) {
+        //console.log("additional items were provided by the machine selector");
+        if (itemIngredients && itemIngredients.forEach) {
+            itemIngredients = itemIngredients.concat(machSelObj.additionalItems);
+        }
+        else {
+            itemIngredients = machSelObj.additionalItems;
+        }
+    }
+    if (machSelObj.additionalFluids && machSelObj.additionalFluids.length > 0) {
+        //console.log("additional fluids were provided by the machine selector");
+        if (fluidIngredients && fluidIngredients.forEach) {
+            fluidIngredients = fluidIngredients.concat(machSelObj.additionalFluids);
+        } else {
+            fluidIngredients = machSelObj.additionalFluids;
+        }
+    }
+
+    var newRecipe = event.recipes.gtceu[machSelObj.machine](recipeName)
+        .duration(machSelObj.duration)
+        .EUt(machSelObj.eu);
+
+    if (useCircuit == true) {
+        newRecipe.circuit(idx);
+    }
+
+    //console.log("process itemIngredients")
+    if (itemIngredients && itemIngredients.length > 0) {
+        //console.log(JsonIO.toString(itemIngredients));
+        newRecipe.itemInputs(itemIngredients);
+    }
+
+    //console.log("process fluidIngredients")
+    if (fluidIngredients && fluidIngredients.length > 0) {
+        //console.log(JsonIO.toString(fluidIngredients))
+        newRecipe.inputFluids(fluidIngredients);
+    }
+
+    //console.log("process itemResults")
+    if (itemResults && itemResults.length > 0) {
+        //console.log(JsonIO.toString(itemResults));
+        newRecipe.itemOutputs(itemResults);
+    }
+
+    //console.log("process fluidResults")
+    if (fluidResults && fluidResults.length > 0) {
+        //console.log(JsonIO.toString(fluidResults))
+        newRecipe.outputFluids(fluidResults);
+    }
+
+//    console.log(`created recipe '${recipeName}' @ '${newRecipe}'
+//            \tinput items: ${JsonIO.toString(itemIngredients)}
+//            \tinput fluids: ${JsonIO.toString(fluidIngredients)}
+//            \toutput items: ${JsonIO.toString(itemResults)}
+//            \toutput fluids: ${JsonIO.toString(fluidResults)}
+//            `);
+
+    addedRecipes.push(recipeName);
+}
+
+//I had a lot of trouble adding objects to the machine recipe input, so I'm just using raw js objects instead
+function autoportFactoryIngredientWrapper(ingredientOrResult) {
+    if (ingredientOrResult.forEach == null) {
+        //just one!
+        //console.log(`processing Ingredient for '${ingredientOrResult.toString()}'`)
+
+        var ret = {};
+        if (ingredientOrResult.has("fluid")) {
+            ret.fluid = ingredientOrResult.get("fluid").toString().replaceAll("\"", "");
+            ret.amount = ingredientOrResult.has("amount") ? parseInt(ingredientOrResult.get("amount")) : 1;
+        }
+        else if (ingredientOrResult.has("fluidTag")) {
+            ret.fluidTag = ingredientOrResult.get("fluidTag").toString().replaceAll("\"", "");
+            ret.amount = ingredientOrResult.has("amount") ? parseInt(ingredientOrResult.get("amount")) : 1;
+        }
+        else if (ingredientOrResult.has("item")) {
+            ret.item = ingredientOrResult.get("item").toString().replaceAll("\"", "");
+            ret.count = ingredientOrResult.has("count") ? parseInt(ingredientOrResult.get("count")) : 1;
+        }
+        else if (ingredientOrResult.has("tag")) {
+            ret.tag = ingredientOrResult.get("tag").toString().replaceAll("\"", "");
+            ret.count = ingredientOrResult.has("count") ? parseInt(ingredientOrResult.get("count")) : 1;
+        }
+
+        return ret;
+    }
+    else if (ingredientOrResult.length && ingredientOrResult.length == 0) {
+        return null;
+    }
+    else {
+        var arr = [];
+        ingredientOrResult.forEach((x) => {
+            //while the method is recursive and could handle this, flattening the output isn't desired
+            if (x.forEach != null && x.length && x.length > 0) {
+                var subArr = [];
+                x.forEach((y) => {
+                    var query = autoportFactoryIngredientWrapper(y);
+                    if (query != null)
+                        subArr.push(query);
+                });
+                if (subArr.length > 0)
+                    arr.push(subArr);
+            }
+            else {
+                var query = autoportFactoryIngredientWrapper(x);
+                if (query != null)
+                    arr.push(query)
+            }
+        });
+        return arr;
+    }
+}
+
+/// Returns a new javascript array of ingredients filtered by the predicate
+function autoportIngredientResultFilter(javaArrayList, predicate) {
+    //console.log(`performing autoportIngredientResultFilter on ${javaArrayList}...`);
+    var arr = [];
+
+    if (javaArrayList.forEach == null) {
+        //filtering just a single item/fluid I guess?
+        if (predicate(javaArrayList) === true) {
+            arr.push(autoportFactoryIngredientWrapper(javaArrayList));
+        }
+    }
+    else {
+        javaArrayList.forEach((x) => {
+            //I don't know how to instanceof to check the type so I'm falling back to a getClass()
+            if (x.getClass() == "class com.google.gson.JsonObject") {
+                if (predicate(x) === true) {
+                    arr.push(autoportFactoryIngredientWrapper(x))
+                }
+            }
+            else if (x.getClass() == "class com.google.gson.JsonArray") {
+                var subArr = [];
+                x.forEach((y) => {
+                    if (predicate(y) === true) {
+                        subArr.push(autoportFactoryIngredientWrapper(y))
+                    }
+                })
+                if (subArr.length > 0)
+                    arr.push(subArr);
+            }
+            else {
+                throw new Error(`invalid datatype was passed to autoportIngredientResultFilter: [${x.getClass()}] ${javaArrayList}`)
+            }
+        })
+    }
+    return arr.length > 0 ? arr : null;
+}

--- a/overrides/kubejs/server_scripts/Recipes/port_food_recipes.js
+++ b/overrides/kubejs/server_scripts/Recipes/port_food_recipes.js
@@ -113,7 +113,7 @@ ServerEvents.recipes(event => {
         }
 
         if (origRecipeName.includes("fried_")) {
-            if ((itemIngredients == null || itemIngredients.length < 7)) {
+            if ((itemIngredients == null || itemIngredients.length < 7) && (fluidIngredients == null || fluidIngredients.length < 2)) {
                 ret.machine = "fryer";
             }
             if (fluidIngredients == null || fluidIngredients.length < 1) {

--- a/overrides/kubejs/server_scripts/Recipes/port_food_recipes.js
+++ b/overrides/kubejs/server_scripts/Recipes/port_food_recipes.js
@@ -343,7 +343,7 @@ function autoportRecipe(addedRecipes, event, recipe, machineSelectorFunction, re
 
     //we're gunna (potentially) do some recursive stuff because having an ingredient as an array of tags just doesn't work
     //ingredients are an array
-    if (itemIngredients.forEach != null) {
+    if (itemIngredients && itemIngredients.forEach != null) {
         //{result={"item":"vegandelight:tofu"}, ingredients=[[{"item":"vegandelight:soymilk_bucket"},{"item":"vegandelight:soymilk_bottle"}],
         //[{"tag":"forge:salts"},{"tag":"forge:salt"}]], type="farmersdelight:cooking", experience=1.0, recipe_book_tab="meals", cookingtime=200}
 
@@ -400,7 +400,7 @@ function autoportRecipe(addedRecipes, event, recipe, machineSelectorFunction, re
                 //add another recipe for milk (liquid) if milk (bucket) is present
                 //todo: update this to support fluids based on a dictionary of item => fluid conversion
                 if (recursiveCall == false) {
-                    if (ingredient.item == "minecraft:milk_bucket") {
+                    if (ingredient.item == "minecraft:milk_bucket" || ingredient.tag == "forge:milk") {
                         //console.log("recipe using milk bucket found, creating duplicate using milk fluid...")
                         var newIngredients = itemIngredients.slice();
                         newIngredients.splice(newIngredients.indexOf(ingredient), 1);
@@ -436,7 +436,12 @@ function autoportRecipe(addedRecipes, event, recipe, machineSelectorFunction, re
     //check for container requirements, such as bowls, and add them to the ingredients list
     if (recipe.json.has("container")){
         var container = recipe.json.get("container");
-        itemIngredients.push(container);
+        if (itemIngredients) {
+            itemIngredients.push(container);
+        }
+        else {
+            itemIngredients = [container];
+        }
         //console.log(`appended container '${container}'`);
     }
     //wow I... hate this

--- a/overrides/kubejs/server_scripts/Recipes/port_food_recipes.js
+++ b/overrides/kubejs/server_scripts/Recipes/port_food_recipes.js
@@ -381,6 +381,10 @@ function autoportRecipe(addedRecipes, event, recipe, machineSelectorFunction, re
                         newIngredients.splice(newIngredients.indexOf(ingredient), 1);
                         newIngredients.push(itemEntries);
 
+                        if (fluidIngredients && fluidIngredients.length > 0) {
+                            newIngredients = newIngredients.concat(fluidIngredients);
+                        }
+
                         if (recipe.json.has("ingredient")) {
                             recipe.json.remove("ingredient");
                         }

--- a/overrides/kubejs/server_scripts/Recipes/port_food_recipes.js
+++ b/overrides/kubejs/server_scripts/Recipes/port_food_recipes.js
@@ -113,10 +113,10 @@ ServerEvents.recipes(event => {
         }
 
         if (origRecipeName.includes("fried_")) {
-            if ((itemIngredients == null || itemIngredients.length < 7) && (fluidIngredients == null || fluidIngredients.length < 2)) {
+            if ((itemIngredients == null || itemIngredients.length < 7)) {
                 ret.machine = "fryer";
             }
-            if (fluidIngredients && fluidIngredients.length < 1) {
+            if (fluidIngredients == null || fluidIngredients.length < 1) {
                 ret.additionalFluids.push([{fluid: "gtceu:seed_oil", amount: 20}, {fluid: "gtceu:fish_oil", amount: 20}]);
             }
         }

--- a/overrides/kubejs/server_scripts/Recipes/port_food_recipes.js
+++ b/overrides/kubejs/server_scripts/Recipes/port_food_recipes.js
@@ -396,6 +396,35 @@ function autoportRecipe(addedRecipes, event, recipe, machineSelectorFunction, re
                     }
                 }
             }
+            else {
+                //add another recipe for milk (liquid) if milk (bucket) is present
+                //todo: update this to support fluids based on a dictionary of item => fluid conversion
+                if (recursiveCall == false) {
+                    if (ingredient.item == "minecraft:milk_bucket") {
+                        //console.log("recipe using milk bucket found, creating duplicate using milk fluid...")
+                        var newIngredients = itemIngredients.slice();
+                        newIngredients.splice(newIngredients.indexOf(ingredient), 1);
+
+                        var newFluidIngredients = fluidIngredients == null ? [] : fluidIngredients.slice();
+                        newFluidIngredients.push({fluid: "minecraft:milk", amount: 1000});
+
+                        newIngredients = newIngredients.concat(newFluidIngredients);
+
+                        if (recipe.json.has("ingredient")) {
+                            recipe.json.remove("ingredient");
+                        }
+                        if (recipe.json.has("ingredients")) {
+                            recipe.json.remove("ingredients");
+                        }
+                        recipe.json.add("ingredients", newIngredients);
+
+                        //console.log("adding new recipe using ingredients: " + JsonIO.toString(newIngredients));
+                        addedRecipes.push(recipeName); //workaround to generate a circuit for the new recipe and not create a duplicate
+                        autoportRecipe(addedRecipes, event, recipe, machineSelectorFunction, recipeBlacklistPredicate);
+                        addedRecipes.splice(addedRecipes.indexOf(recipeName), 1); //if the above errors, splice(length-2) is invalid
+                    }
+                }
+            }
         });
 
         if (recursiveCall == true) {

--- a/overrides/kubejs/server_scripts/Recipes/port_food_recipes.js
+++ b/overrides/kubejs/server_scripts/Recipes/port_food_recipes.js
@@ -406,6 +406,13 @@ function autoportRecipe(addedRecipes, event, recipe, machineSelectorFunction, re
         }
     }
 
+    if (machSelObj.machine == "slicer" && itemIngredients.find) {
+        var findTheKnife = itemIngredients.find(x=>x.tag == "forge:tools/knives");
+        if (findTheKnife != null) {
+            itemIngredients.splice(itemIngredients.indexOf(findTheKnife))
+        }
+    }
+
     //console.log(`machine selected: ${JsonIO.toString(machSelObj)}`)
 
     if (machSelObj.additionalItems && machSelObj.additionalItems.length > 0) {

--- a/overrides/kubejs/server_scripts/Recipes/port_food_recipes.js
+++ b/overrides/kubejs/server_scripts/Recipes/port_food_recipes.js
@@ -231,7 +231,9 @@ function autoportRecipe(addedRecipes, event, recipe, machineSelectorFunction, re
     //I hate indexing it this way; if someone knows how to do this better please do
     //these should all be com.google.gson.JsonArray
     var ingredients = recipe.json.has("ingredient") ? recipe.json.get("ingredient") : recipe.json.get("ingredients");
-    var toolIngredient = recipe.json.has("tool") ? recipe.json.get("tool") : recipe.json.get("tool");
+    var toolIngredient = recipe.json.has("tool") ? recipe.json.get("tool") : null; //barbequesdelight support
+    var sideIngredient = recipe.json.has("side") ? recipe.json.get("side") : null; //barbequesdelight support
+    var ingredientCount = recipe.json.has("ingredientCount") ? parseInt(recipe.json.get("ingredientCount")): null; //WHYYY
     var results = recipe.json.has("result") ? recipe.json.get("result")
     : recipe.json.has("results") ? recipe.json.get("results")
     : recipe.json.has("output") ? recipe.json.get("output")
@@ -246,6 +248,10 @@ function autoportRecipe(addedRecipes, event, recipe, machineSelectorFunction, re
         toolIngredient = JsonIO.parse(JsonIO.toString([toolIngredient]));
         //console.log("transformed ingredients into array");
     }
+    if (sideIngredient != null && (sideIngredient.getClass == undefined || sideIngredient.getClass() == "class com.google.gson.JsonObject")) {
+        sideIngredient = JsonIO.parse(JsonIO.toString([sideIngredient]));
+        //console.log("transformed sideIngredient into array");
+    }
 
     if (results != null && (results.getClass == undefined || results.getClass() == "class com.google.gson.JsonObject")) {
         results = JsonIO.parse(JsonIO.toString([results]));
@@ -254,6 +260,30 @@ function autoportRecipe(addedRecipes, event, recipe, machineSelectorFunction, re
     if (secondaryOutputs != null && (secondaryOutputs.getClass == undefined || secondaryOutputs.getClass() == "class com.google.gson.JsonObject")) {
         secondaryOutputs = JsonIO.parse(JsonIO.toString([secondaryOutputs]));
         //console.log("transformed secondaryOutputs into array");
+    }
+
+    if (sideIngredient != null) {
+        if (sideIngredient.length > 0) {
+            ingredients.addAll(sideIngredient);
+        }
+    }
+
+    //i hate you barbeques delight
+    if (ingredientCount != null && ingredientCount > 1) {
+        var newIngs = [];
+        ingredients.forEach((x) => {
+            //this just doesn't work for some reason? maybe just for tags but aaaaaaahhhhhh
+//            if (x.has("count")) {
+//                x.remove("count");
+//            }
+//            x.add("count", ingredientCount);
+            for (let i = 0; i < ingredientCount - 1; i++) {
+                newIngs.push(x)
+            }
+        })
+        if (newIngs.length > 0) {
+            ingredients.addAll(newIngs);
+        }
     }
 
     //console.log("raw json ingredients:")
@@ -267,6 +297,7 @@ function autoportRecipe(addedRecipes, event, recipe, machineSelectorFunction, re
             //console.log("appended tool ingredients to ingredients");
         }
     }
+
     //console.log("raw json results:")
     //console.log(results)
     if (secondaryOutputs != null) {
@@ -288,6 +319,8 @@ function autoportRecipe(addedRecipes, event, recipe, machineSelectorFunction, re
     //e.g. [[{"item":"vegandelight:soymilk_bucket"},{"item":"vegandelight:soymilk_bottle"}], [{"tag":"forge:salts"},{"tag":"forge:salt"}], [{"item":"minecraft:water_bucket"}]]
     var itemIngredients = autoportIngredientResultFilter(ingredients, itemPredicate);
     var fluidIngredients = autoportIngredientResultFilter(ingredients, fluidPredicate);
+
+
 
     //console.log("parsed json ingredients:")
     //console.log(JsonIO.toString(itemIngredients));


### PR DESCRIPTION
This PR supercedes #591 as it is a more holistic approach

Adds GT machine recipes for food recipes from the following sources:
 - farmersdelight:cutting
 - farmersdelight:cooking
 - vintagedelight:fermenting
 - barbequesdelight:skewering
 - barbequesdelight:grilling

This supports tag-array'd-ingredients and splits recipes across multiple circuits
<img width="450" height="300" alt="image" src="https://github.com/user-attachments/assets/6e8c706a-12c7-44ec-b2f7-37d2eec7b61d" />
<img width="519" height="488" alt="image" src="https://github.com/user-attachments/assets/4826298c-30c9-4d22-a905-76cb70564206" />
<img width="522" height="496" alt="image" src="https://github.com/user-attachments/assets/9c61d4f1-b070-4f67-872e-409bb7e9f7b6" />

As the fryer meow has recipes again and I felt like it made sense, I have added [seed oil / fish oil] as a fluid ingredient to the recipes for foods with 'fried_' (EMI only shows the other fluids on hover)
<img width="526" height="444" alt="image" src="https://github.com/user-attachments/assets/ede14451-e394-4652-9e62-fdbb8df94f1d" />
<img width="382" height="175" alt="image" src="https://github.com/user-attachments/assets/b271c204-fcb8-4f06-b6e8-a47e22c969d3" />
<img width="323" height="148" alt="image" src="https://github.com/user-attachments/assets/867b3643-3ed3-469f-a32e-0a4f3420c71e" />

The performance impact / load time is negligible:
<img width="1139" height="195" alt="image" src="https://github.com/user-attachments/assets/ce5a8921-4965-4430-8afd-d3fc8fbe03ad" />


This can be scaled to other recipe sources later as well if more or different food mods are added. It should even work for non-food things, theoretically.
This does *not* read or touch any recipes from the standard crafting grid.

I have looked at over 300 recipes generated by this and do not currently observe any logic issues with the implementation.