### PR TITLE
Fix typo in release zips

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: build-artifacts-${{ github.event.release.tag_name }}
-          path: Cosmic.Frontier*.zip
+          path: Cosmic.Frontiers*.zip
           if-no-files-found: error
           retention-days: 3
 
@@ -51,7 +51,7 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ github.event.release.tag_name }}
-          files: ./Cosmic.Frontier.${{ github.event.release.tag_name }}.zip
+          files: ./Cosmic.Frontiers.${{ github.event.release.tag_name }}.zip
           fail_on_unmatched_files: true
 
   publish-curseforge:
@@ -72,8 +72,8 @@ jobs:
         with:
           curseforge-id: ${{ vars.CURSE_ID }}
           curseforge-token: ${{ secrets.CURSE_TOKEN }}
-          files: ./Cosmic.Frontier*.zip
-          name: "Cosmic Frontier ${{ github.event.release.tag_name }}"
+          files: ./Cosmic.Frontiers*.zip
+          name: "Cosmic Frontiers ${{ github.event.release.tag_name }}"
           version: ${{ github.event.release.tag_name }}
           changelog: ${{ github.event.release.body }}
           version-type: release

--- a/scripts/pack_generation.py
+++ b/scripts/pack_generation.py
@@ -33,7 +33,7 @@ def generate_modpack_zip(version=None):
         copy_any(modlist_src, modpack_dir)
 
     # Zip the directory (only include the contents, not the root folder)
-    zip_name = f'Cosmic.Frontier.{version}.zip' if version else f'Cosmic.Frontier.zip'
+    zip_name = f'Cosmic.Frontiers.{version}.zip' if version else f'Cosmic.Frontiers.zip'
     zip_path = os.path.join(root_dir, zip_name)
     with zipfile.ZipFile(zip_path, 'w', zipfile.ZIP_DEFLATED) as zipf:
         for root, dirs, files in os.walk(modpack_dir):

--- a/scripts/server_generation.py
+++ b/scripts/server_generation.py
@@ -55,7 +55,7 @@ def generate_serverpack_zip(version=None, curseforge_api_key=None):
     readme_update(root_dir, serverpack_dir)
 
     # Zip the directory (only include the contents, not the root folder)
-    zip_name = f'Cosmic.Frontier.Server.{version}.zip' if version else f'Cosmic.Frontier.Server.zip'
+    zip_name = f'Cosmic.Frontiers.Server.{version}.zip' if version else f'Cosmic.Frontiers.Server.zip'
     zip_path = os.path.join(root_dir, zip_name)
     with zipfile.ZipFile(zip_path, 'w', zipfile.ZIP_DEFLATED) as zipf:
         for root, dirs, files in os.walk(serverpack_dir):


### PR DESCRIPTION
Release zips are currently called Cosmic.Frontier.{version}.zip (singular Frontier)
Changes this to be Cosmic.Frontier**s**.{version}.zip