### PR TITLE
Replace Ad Astra tag references with GT items + fix iron sliding door recipe

### DIFF
--- a/overrides/kubejs/server_scripts/Recipes/Ad_Astra.js
+++ b/overrides/kubejs/server_scripts/Recipes/Ad_Astra.js
@@ -454,6 +454,11 @@ ServerEvents.recipes(event => {
     'ad_astra:steel_rod',
     'gtceu:steel_rod'
   )
+  event.replaceInput(
+    { id: 'ad_astra:iron_sliding_door' },
+    '#ad_astra:steel_blocks',
+    'minecraft:iron_block'
+  )
 })
 
 

--- a/overrides/kubejs/server_scripts/Recipes/Ad_Astra.js
+++ b/overrides/kubejs/server_scripts/Recipes/Ad_Astra.js
@@ -425,6 +425,26 @@ ServerEvents.recipes(event => {
     'ad_astra:desh_block'
   )
   event.replaceInput(
+    { input: '#ad_astra:steel_block' },
+    '#ad_astra:steel_blocks',
+    'gtceu:steel_block'
+  )
+  event.replaceInput(
+    { input: '#ad_astra:iron_plates' },
+    '#ad_astra:iron_plates',
+    'gtceu:iron_plate'
+  )
+  event.replaceInput(
+    { input: '#ad_astra:steel_plates' },
+    '#ad_astra:steel_plates',
+    'gtceu:steel_plate'
+  )
+  event.replaceInput(
+    { input: '#ad_astra:steel_ingots' },
+    '#ad_astra:steel_ingots',
+    'gtceu:steel_ingot'
+  )
+  event.replaceInput(
     { input: 'ad_astra:iron_rod' },
     'ad_astra:iron_rod',
     'gtceu:iron_rod'


### PR DESCRIPTION
Replaces Ad Astra's references to steel blocks, steel ingots, steel plates, and iron plates with GT items. Also changes the iron sliding door recipe to use an iron block instead of steel block.