### PR TITLE
EMI tab ordering for Advanced Loot Info

### DIFF
--- a/overrides/kubejs/assets/emi/category/properties/emi.json
+++ b/overrides/kubejs/assets/emi/category/properties/emi.json
@@ -1,0 +1,29 @@
+{
+    "ali:entity_loot": {
+        "order": 992
+    },
+    "ali:chest_loot": {
+        "order": 993
+    },
+    "ali:block_loot": {
+        "order": 994
+    },
+    "ali:trade_loot": {
+        "order": 995
+    },
+    "ali:gameplay_loot": {
+        "order": 996
+    },
+    "ali:plant_loot": {
+        "order": 997
+    },
+    "ali:fishing_loot": {
+        "order": 998
+    },
+    "ali:archaeology_loot": {
+        "order": 999
+    },
+    "ali:hero_loot": {
+        "order": 1000
+    }
+}


### PR DESCRIPTION
Sorts all tabs added by Advanced Loot Info (block drops, entity drops, gameplay loot, etc.) to the end of EMI ordering