### PR TITLE
Add recipes for Simply Swords' netherite and runic scythes

### DIFF
--- a/overrides/kubejs/server_scripts/Recipes/SimplySwords.js
+++ b/overrides/kubejs/server_scripts/Recipes/SimplySwords.js
@@ -25,7 +25,8 @@ ServerEvents.recipes( e => {
         'greathammer',  
         'greataxe', 
         'chakram',
-        'halberd'
+        'halberd',
+        'scythe'
     ]
     
 


### PR DESCRIPTION
Scythe was missing from the weapons array in SimplySwords.js