### PR TITLE
rebalance some dehydrator and extractor recipes for magma, netherrack, soulresin, cinedrwax

### DIFF
--- a/overrides/kubejs/server_scripts/Recipes/Cosmic_Frontiers.js
+++ b/overrides/kubejs/server_scripts/Recipes/Cosmic_Frontiers.js
@@ -303,13 +303,25 @@ ServerEvents.recipes(event => {
        event.recipes.gtceu.chemical_dehydrator('lava_to_magma_block')
               .inputFluids('minecraft:lava 1000')
               .itemOutputs('minecraft:magma_block')
-              .duration(150)
-              .EUt(GTValues.VA[GTValues.MV]);
+              .duration(100)
+              .EUt(20,);
        event.recipes.gtceu.chemical_dehydrator('magma_block_to_netherrack')
               .itemInputs('minecraft:magma_block')
               .itemOutputs('minecraft:netherrack')
-              .duration(100)
-              .EUt(GTValues.VA[GTValues.MV]);
+              .duration(10)
+              .EUt(20,);
+       event.remove({ id: "gtceu:extractor/soul_resin_extractor" })
+       event.recipes.gtceu.extractor('soul_resin_extraction')
+              .itemInputs('legendarysurvivaloverhaul:ice_fern_leaf')
+              .outputFluids('gtceu:soulresin 144')
+              .duration(20)
+              .EUt(2,);
+       event.remove({ id: "gtceu:extractor/cinder_wax_extractor" })
+       event.recipes.gtceu.extractor('cinder_wax_extraction')
+              .itemInputs('nethersdelight:propelpearl')
+              .outputFluids('gtceu:cinderwax 144')
+              .duration(20)
+              .EUt(2,);
        //Basic Circuit Shit, the steam assembler re-routes all the basic parts to be mandatory in it, as otherwise who cares.
        event.remove({ output: "gtceu:resistor" })
        event.recipes.gtceu.assembler('resistor_good')

--- a/overrides/kubejs/server_scripts/Recipes/Cosmic_Frontiers.js
+++ b/overrides/kubejs/server_scripts/Recipes/Cosmic_Frontiers.js
@@ -304,24 +304,24 @@ ServerEvents.recipes(event => {
               .inputFluids('minecraft:lava 1000')
               .itemOutputs('minecraft:magma_block')
               .duration(100)
-              .EUt(20,);
+              .EUt(20);
        event.recipes.gtceu.chemical_dehydrator('magma_block_to_netherrack')
               .itemInputs('minecraft:magma_block')
               .itemOutputs('minecraft:netherrack')
               .duration(10)
-              .EUt(20,);
+              .EUt(20);
        event.remove({ id: "gtceu:extractor/soul_resin_extractor" })
        event.recipes.gtceu.extractor('soul_resin_extraction')
               .itemInputs('legendarysurvivaloverhaul:ice_fern_leaf')
               .outputFluids('gtceu:soulresin 144')
               .duration(20)
-              .EUt(2,);
+              .EUt(2);
        event.remove({ id: "gtceu:extractor/cinder_wax_extractor" })
        event.recipes.gtceu.extractor('cinder_wax_extraction')
               .itemInputs('nethersdelight:propelpearl')
               .outputFluids('gtceu:cinderwax 144')
               .duration(20)
-              .EUt(2,);
+              .EUt(2);
        //Basic Circuit Shit, the steam assembler re-routes all the basic parts to be mandatory in it, as otherwise who cares.
        event.remove({ output: "gtceu:resistor" })
        event.recipes.gtceu.assembler('resistor_good')


### PR DESCRIPTION
previous recipes were just outright way worse than say using a mechanical squeezer/drying basin
like magma > netherrack being 10x slower and costing 60x more energy (also being mv instead of steam)
<img width="312" height="187" alt="image" src="https://github.com/user-attachments/assets/e499ab90-c9b9-4f8c-8d0b-bc51a930977f" />
<img width="531" height="439" alt="image" src="https://github.com/user-attachments/assets/18cfb5b5-5490-4a6a-bbfb-14ff04d3312a" />

new recipe is the same duration and eu cost as the drying basin one
same goes for the other recipes except for the extraction ones cause i cant really make them require no energy like the mechanical squeezer

squeezer recipe compared to the new recipe 
<img width="553" height="284" alt="image" src="https://github.com/user-attachments/assets/3ad4f9f4-dbfa-4738-9c69-4af316a2b533" />
<img width="565" height="354" alt="image" src="https://github.com/user-attachments/assets/5343a3dc-8f48-49d6-ba87-5144ba1b98f1" />

old recipe
<img width="411" height="265" alt="image" src="https://github.com/user-attachments/assets/b423bd95-03c1-4b37-916b-b6e507b759e1" />

just didnt make sense for the gt recipes to be worse 🔥 

