### PR TITLE
increase progress/xp amount per hit for tinkers improvable bows and armor

### DIFF
--- a/overrides/defaultconfigs/tinkerslevellingaddon-server.toml
+++ b/overrides/defaultconfigs/tinkerslevellingaddon-server.toml
@@ -232,7 +232,7 @@
 		#Range: > 0
 		shooting = 9
 		#Range: > 0
-		takingDamage = 1
+		takingDamage = 3
 		#Range: > 0
 		blockingDamage = 0
 		#As with Thorns damage calculations, this is the upper bound of the bonus experience that could be granted.

--- a/overrides/defaultconfigs/tinkerslevellingaddon-server.toml
+++ b/overrides/defaultconfigs/tinkerslevellingaddon-server.toml
@@ -232,13 +232,13 @@
 		#Range: > 0
 		shooting = 9
 		#Range: > 0
-		takingDamage = 3
+		takingDamage = 5
 		#Range: > 0
 		blockingDamage = 0
 		#As with Thorns damage calculations, this is the upper bound of the bonus experience that could be granted.
 		#For example, for the value of 3 (default), we get: 1 (base xp) + 0 to 3 (bonus xp) = 1 to 4 (result xp)
 		#Range: > 0
-		thorns = 3
+		thorns = 10
 		#Range: > 0
 		flying = 0
 		#Range: > 0

--- a/overrides/defaultconfigs/tinkerslevellingaddon-server.toml
+++ b/overrides/defaultconfigs/tinkerslevellingaddon-server.toml
@@ -230,9 +230,9 @@
 		#Range: > 0
 		attacking = 0
 		#Range: > 0
-		shooting = 0
+		shooting = 9
 		#Range: > 0
-		takingDamage = 0
+		takingDamage = 1
 		#Range: > 0
 		blockingDamage = 0
 		#As with Thorns damage calculations, this is the upper bound of the bonus experience that could be granted.


### PR DESCRIPTION
takes less time to level the armor, possibly less afking to level it, need to play around with this a bit to get a feel
for the bows it now takes 100 arrows for lvl 1, 150 for lvl 2, 225 for lvl 3 etc instead of 1000 > 1500 > 2250
melee weapons can easily get 10+xp/progress per swing so i think this is fair 🤷 