### PR TITLE
Red hook's quest description fix

### DIFF
--- a/overrides/config/ftbquests/quests/chapters/useful_baubles.snbt
+++ b/overrides/config/ftbquests/quests/chapters/useful_baubles.snbt
@@ -1084,7 +1084,7 @@
 				"Might be helpful for builders?"
 			]
 			id: "6AA8F1B9BE4D6FE0"
-			subtitle: "Requires Kanthal"
+			subtitle: "Creative Flight in Certain Areas"
 			tasks: [{
 				id: "4356CDCAE8BF195F"
 				item: "rehooked:red_hook"


### PR DESCRIPTION
According to https://github.com/Frontiers-PackForge/CosmicFrontiers/pull/564#issue-3348763646 ,the red hook no longer needs kanthal,thus changing the quest description to be accurate.