### PR TITLE
Ae2 recipe enhancement

### DIFF
--- a/overrides/kubejs/server_scripts/Recipes/Ae2_Mods.js
+++ b/overrides/kubejs/server_scripts/Recipes/Ae2_Mods.js
@@ -346,11 +346,23 @@ ServerEvents.recipes(event => {
     .duration(160)
     .EUt(GTValues.VA[GTValues.LV]);
   //Energy Cell
-  event.recipes.gtceu.assembler('ae2:cell_assem')
+  event.recipes.gtceu.assembler('ae2:cell_assem_t1')
     .itemInputs(['4x gtceu:steel_plate', '4x ae2:charged_certus_quartz_crystal', 'ae2:energy_acceptor', '#gtceu:batteries/lv'])
     .itemOutputs('ae2:energy_cell')
     .duration(160)
     .EUt(GTValues.VA[GTValues.LV]);
+  //Energy Cell 4x
+  event.recipes.gtceu.assembler('ae2:cell_assem_t2')
+    .itemInputs(['4x gtceu:stainless_steel_plate', '4x ae2:charged_certus_quartz_crystal', '4x ae2:energy_acceptor', '#gtceu:batteries/hv'])
+    .itemOutputs('4x ae2:energy_cell')
+    .duration(160)
+    .EUt(GTValues.VA[GTValues.HV])
+  //Energy Cell 8x
+  event.recipes.gtceu.assembler('ae2:cell_assem_t3')
+    .itemInputs(['4x gtceu:tungsten_steel_plate', '4x ae2:charged_certus_quartz_crystal', '8x ae2:energy_acceptor', '#gtceu:batteries/iv'])
+    .itemOutputs('8x ae2:energy_cell')
+    .duration(160)
+    .EUt(GTValues.VA[GTValues.IV])
   //Dense cell
   event.recipes.gtceu.assembler('ae2:dense_cell_assem')
     .itemInputs(['8x ae2:energy_cell', '16x gtceu:galvanized_ethersteel_plate', '32x gtceu:electrum_foil', '8x gtceu:terrasteel_double_wire'])
@@ -385,11 +397,23 @@ ServerEvents.recipes(event => {
     .EUt(GTValues.VA[GTValues.MV]);
   //Acceptor
   event.remove({ output: 'ae2:energy_acceptor' })
-  event.recipes.gtceu.assembler('ae2:acceptor_assembly')
+  event.recipes.gtceu.assembler('ae2:acceptor_assembly_t1')
     .itemInputs(['6x gtceu:steel_plate', '4x gtceu:lv_voltage_coil', '4x #gtceu:circuits/lv', 'gtceu:lv_machine_hull'])
     .itemOutputs('ae2:energy_acceptor')
     .duration(160)
     .EUt(GTValues.VA[GTValues.LV]);
+  //Acceptor 4x
+  event.recipes.gtceu.assembler('ae2:acceptor_assembly_t2')
+    .itemInputs(['6x gtceu:stainless_steel_plate', '4x gtceu:hv_voltage_coil', '4x #gtceu:circuits/hv', 'gtceu:hv_machine_hull'])
+    .itemOutputs('4x ae2:energy_acceptor')
+    .duration(160)
+    .EUt(GTValues.VA[GTValues.HV])
+  //Acceptor 8x
+  event.recipes.gtceu.assembler('ae2:acceptor_assembly_t3')
+    .itemInputs(['6x gtceu:tungsten_steel_plate', '4x gtceu:iv_voltage_coil', '4x #gtceu:circuits/iv', 'gtceu:iv_machine_hull'])
+    .itemOutputs('8x ae2:energy_acceptor')
+    .duration(160)
+    .EUt(GTValues.VA[GTValues.IV])
   //Controller
   event.recipes.gtceu.circuit_assembler('ae2:controller_assembly')
     .itemInputs(['4x gtceu:manasteel_hex_wire', '4x #gtceu:circuits/mv', '4x malum:cluster_of_brilliance', 'ae2:energy_acceptor'])
@@ -574,12 +598,26 @@ ServerEvents.recipes(event => {
     .duration(15)
     .EUt(GTValues.VA[GTValues.MV]);
   //Patterns bc apparently we lost em
-  event.recipes.gtceu.assembler('pattern_recipe')
+  event.recipes.gtceu.assembler('pattern_recipe_hv')
     .itemInputs(['32x gtceu:fine_galvanized_ethersteel_wire', '16x gtceu:stainless_steel_plate', '2x #gtceu:circuits/hv', 'gtceu:diamond_lens'])
     .inputFluids(`gtceu:soldering_alloy 576`)
     .itemOutputs('8x ae2:blank_pattern')
     .duration(90)
     .EUt(GTValues.VA[GTValues.HV]);
+  //Patterns use IV material, 4x
+  event.recipes.gtceu.assembler('pattern_recipe_iv')
+    .itemInputs(['32x gtceu:fine_virtue_meld_wire', '16x gtceu:tungsten_steel_plate', '2x #gtceu:circuits/iv', 'gtceu:diamond_lens'])
+    .inputFluids('gtceu:soldering_alloy 576')
+    .itemOutputs('32x ae2:blank_pattern')
+    .duration(90)
+    .EUt(GTValues.VA[GTValues.IV])
+  //Patterns use LuV material, 8x
+  event.recipes.gtceu.assembler('pattern_recipe_luv')
+    .itemInputs(['32x cosmiccore:fine_prismatic_tungstensteel_wire', '16x gtceu:rhodium_plated_palladium_plate', '2x #gtceu:circuits/luv', 'gtceu:diamond_lens'])
+    .inputFluids('gtceu:soldering_alloy 576')
+    .itemOutputs('64x ae2:blank_pattern')
+    .duration(90)
+    .EUt(GTValues.VA[GTValues.LuV])
 
   //Extended Ae2
   event.recipes.gtceu.assembler('extended_interface')

--- a/overrides/kubejs/startup_scripts/Materials/Cosmic_Frontiers_Materials.js
+++ b/overrides/kubejs/startup_scripts/Materials/Cosmic_Frontiers_Materials.js
@@ -127,8 +127,8 @@ GTCEuStartupEvents.registry('gtceu:material', event => {
             GTMaterialFlags.GENERATE_SPRING_SMALL,
             GTMaterialFlags.GENERATE_FOIL,
             GTMaterialFlags.NO_SMELTING,
-            GTMaterialFlags.NO_ORE_SMELTING
-
+            GTMaterialFlags.NO_ORE_SMELTING,
+            GTMaterialFlags.GENERATE_FINE_WIRE
         )
     event.create('utherium')
         .color(0xc3434c)


### PR DESCRIPTION
While crafting a Quantum Ring for my wireless terminal, I was shocked to discover that I needed 8192 Fine Steel Wires to make just 16 of them. Upon checking the recipe tree, I realized that crafting the Quantum Ring required a massive number of Energy Acceptors and Energy Cells, which I could only produce using the LV-tier recipes.

This process was so inefficient and absurd that I decided to add higher voltage-tier recipes for the Energy Acceptor and Energy Cell to cut down on the pointless wait time (yes, I'm looking at you, Fine Steel Wire). Additionally, I introduced IV and LuV-tier recipes for the Blank Pattern to accommodate the subsequent massive surge in pattern demand later in the game.