### PR TITLE
Move Voiding Jar to Steam

### DIFF
--- a/overrides/config/ftbquests/quests/chapters/useful_baubles.snbt
+++ b/overrides/config/ftbquests/quests/chapters/useful_baubles.snbt
@@ -556,7 +556,7 @@
 			y: 0.0d
 		}
 		{
-			dependencies: ["16C68448A7ADA9D4"]
+			dependencies: ["7B4F0BE29E6CD211"]
 			description: [
 				"Voids items you pick up. Obviously useful for mining."
 				""
@@ -570,8 +570,8 @@
 				item: "ars_nouveau:void_jar"
 				type: "item"
 			}]
-			x: -1.0d
-			y: 0.0d
+			x: -7.0d
+			y: -2.0d
 		}
 		{
 			dependencies: ["16C68448A7ADA9D4"]

--- a/overrides/kubejs/server_scripts/Recipes/ArsNouveau.js
+++ b/overrides/kubejs/server_scripts/Recipes/ArsNouveau.js
@@ -309,6 +309,20 @@ ServerEvents.recipes(event => {
         R: 'gtceu:rose_gold_plate'
     }
     )
+
+    event.remove({ output: 'ars_nouveau:void_jar' })
+    event.shaped('ars_nouveau:void_jar', [
+        'PHP',
+        'GLG',
+        'EGE'
+    ], {
+        P: 'gtceu:steel_plate',
+        H: '#forge:tools/hammers',
+        G: '#forge:glass',
+        L: 'minecraft:lava_bucket',
+        E: '#forge:ender_pearls'
+    })
+    
     //spellbooks
     //incase an occultism recipe is wanted instead
   //event.remove({ id: 'ars_nouveau:novice_spell_book' })


### PR DESCRIPTION
Voiding Jar has no reason to be as high as post-EBF for a small QoL tool. Moved it to Steam 

Closes #694 

hi tom³
