### PR TITLE
Add Nether's Delight machetes and TCon daggers to knife tags for loot

### DIFF
--- a/overrides/kubejs/server_scripts/ItemEvents/Tags.js
+++ b/overrides/kubejs/server_scripts/ItemEvents/Tags.js
@@ -63,8 +63,10 @@ ServerEvents.tags("item", event => {
     
     event.add('forge:chests/wooden', 'framedblocks:framed_chest')
 
-    // Add Nether's Delight machetes to knife tags for loot
-    event.add('occultism:tools/knives', 'nethersdelight:tools/machetes') 
-    event.add('forge:tools/knives', 'nethersdelight:tools/machetes') 
+    // Add Nether's Delight machetes and TiCon daggers to knife tags for loot
+    event.add('occultism:tools/knives', '#nethersdelight:tools/machetes')
+    event.add('occultism:tools/knives', 'tconstruct:dagger')
+    event.add('forge:tools/knives', '#nethersdelight:tools/machetes')
+    event.add('forge:tools/knives', 'tconstruct:dagger')
 })
 

--- a/overrides/kubejs/server_scripts/ItemEvents/Tags.js
+++ b/overrides/kubejs/server_scripts/ItemEvents/Tags.js
@@ -62,5 +62,9 @@ ServerEvents.tags("item", event => {
     event.add("forestry:backpack/allow/apiarist", "minecraft:honeycomb")
     
     event.add('forge:chests/wooden', 'framedblocks:framed_chest')
+
+    // Add Nether's Delight machetes to knife tags for loot
+    event.add('occultism:tools/knives', 'nethersdelight:tools/machetes') 
+    event.add('forge:tools/knives', 'nethersdelight:tools/machetes') 
 })
 


### PR DESCRIPTION
Machetes are intended to be better knives iirc but aren't added to relevant tags used to apply specific loot rolls

Also added TCon daggers because uhhh funny