### PR TITLE
Change vanilla tools recipes slightly to stop the need for polymorph

### DIFF
--- a/overrides/kubejs/server_scripts/Recipes/Cosmic_Frontiers.js
+++ b/overrides/kubejs/server_scripts/Recipes/Cosmic_Frontiers.js
@@ -281,6 +281,9 @@ ServerEvents.recipes(event => {
               E: 'gtceu:empty_spray_can'
        })
 
+       event.replaceInput({ mod: 'gtceu', id: /iron_/, output: '#minecraft:tools'}, 'minecraft:stick', 'gtceu:long_wood_rod')
+       event.replaceInput({ mod: 'gtceu', id: /golden_/, output: '#minecraft:tools'}, 'minecraft:stick', 'gtceu:long_wood_rod')
+       event.replaceInput({ mod: 'gtceu', id: /diamond_/, output: '#minecraft:tools'}, 'minecraft:stick', 'gtceu:long_wood_rod')
 
 
        event.recipes.gtceu.assembler('ug_catalyst')


### PR DESCRIPTION
It finally happened.

<img width="370" height="179" alt="image" src="https://github.com/user-attachments/assets/fe3cbc80-57f6-4bc4-b96a-0cf4f1fcd251" />

vanilla and VANILLA ONLY tools now take long wood rods instead so no need in polymorph for a ritual or a funny book

That change *only* touches tools, i made doubly sure

PRing to such an active file is scary, ping me on discord if i'll have to redo it due to some merge conflict lmao