### PR TITLE
make hose pulley continue filling an area after it is considered infinite

### DIFF
--- a/overrides/defaultconfigs/create-server.toml
+++ b/overrides/defaultconfigs/create-server.toml
@@ -341,7 +341,7 @@
 	hosePulleyBlockThreshold = 10000
 	#.
 	#Whether hose pulleys should continue filling up above-threshold sources.
-	fillInfinite = false
+	fillInfinite = true
 	#.
 	#Configure which fluids can be drained infinitely.
 	#Allowed Values: ALLOW_ALL, DENY_ALL, ALLOW_BY_TAG, DENY_BY_TAG


### PR DESCRIPTION
got a bug on the server where the area isnt actually infinite yet but it considers it infinite so it wont place more fluid sources