### PR TITLE
Fix some recipe inconsistencies from Aether and Terralith

### DIFF
--- a/overrides/kubejs/server_scripts/Recipes/Cosmic_Frontiers.js
+++ b/overrides/kubejs/server_scripts/Recipes/Cosmic_Frontiers.js
@@ -148,12 +148,12 @@ ServerEvents.recipes(event => {
        event.remove({ id: 'bhc:god_apple' })
        event.remove({ id: 'create:industrial_iron_block_from_ingots_iron_stonecutting' })
        event.remove({ id: 'biomesoplenty:tnt_from_bop_sand' })
-       event.remove({ id: 'terralith:observer_alt' })
+       // Remove all of Terralith's alt recipes for vanilla blocks (e.g Dropper, Observer, Lever, Dispenser, Piston)
+       event.remove({ id: /terralith:(.*)_alt/ })
 
        event.remove({ mod: 'biomancy' })
 
      //stone buttons bruh
-     event.remove({ id: 'terralith:lever_alt' })
      event.shaped('6x minecraft:stone_button', [
              '   ',
              'TP ',

--- a/overrides/kubejs/server_scripts/Recipes/Gregtech/Gregtech.js
+++ b/overrides/kubejs/server_scripts/Recipes/Gregtech/Gregtech.js
@@ -114,7 +114,6 @@ ServerEvents.recipes(event => {
   event.remove({ id: 'gtceu:vacuum_freezer/cool_hot_neutronite_ingot' })
   event.remove({ id: 'gtceu:alloy_smelter/alloy_smelt_terrasteel_dust_to_block' })
   event.remove({ id: 'gtceu:alloy_smelter/alloy_smelt_rhenium_dust_to_block' })
-  event.remove({ id: 'terralith:piston_alt' })
   event.remove({ id: 'gtceu:macerator/macerate_treated_wood_planks' })
   event.remove({ id: 'gtceu:alloy_blast_smelter/starmetal_gas' })
   event.remove({ id: 'gtceu:orbital_forge/neutronium_boule' })

--- a/overrides/kubejs/server_scripts/Recipes/Gregtech/Wood/GregtechWoodMisc.js
+++ b/overrides/kubejs/server_scripts/Recipes/Gregtech/Wood/GregtechWoodMisc.js
@@ -45,6 +45,8 @@ ServerEvents.recipes(event => {
     event.remove({ id: 'minecraft:kjs/aether_skyroot_fence' })
     event.remove({ id: 'aether:skyroot_bed' })
     event.remove({ id: 'aether:skyroot_stick' })
+    event.remove({ id: 'aether:skyroot_chest'})
+    event.remove({ id: 'aether:skyroot_lectern'})
 
 
     //DANGEROUS : WOOD PLANK REMOVALS - BY RECIPE - if something is broken attempt to check it against this matcher first
@@ -92,6 +94,10 @@ ServerEvents.recipes(event => {
             P: '#forge:logs/archwood'
         })
     event.shapeless('2x ars_nouveau:archwood_planks', ['#forge:logs/archwood'])
+})
+
+ServerEvents.tags('item', event => {
+    event.add('minecraft:planks', 'aether:skyroot_planks')
 })
 
 ServerEvents.recipes(event => {

--- a/overrides/kubejs/server_scripts/Recipes/Gregtech/Wood/GregtechWoodMisc.js
+++ b/overrides/kubejs/server_scripts/Recipes/Gregtech/Wood/GregtechWoodMisc.js
@@ -45,8 +45,6 @@ ServerEvents.recipes(event => {
     event.remove({ id: 'minecraft:kjs/aether_skyroot_fence' })
     event.remove({ id: 'aether:skyroot_bed' })
     event.remove({ id: 'aether:skyroot_stick' })
-    event.remove({ id: 'aether:skyroot_chest'})
-    event.remove({ id: 'aether:skyroot_lectern'})
 
 
     //DANGEROUS : WOOD PLANK REMOVALS - BY RECIPE - if something is broken attempt to check it against this matcher first


### PR DESCRIPTION
This removes the following recipes from Terralith:
- All recipes Terralith adds ending with `_alt` matched with regex
- This covers Dispenser, Dropper, Lever, Observer, Piston and all others that might have been missed

Also adds `minecraft:planks` tag to Skyroot Planks