### PR TITLE
fix some qb nodes missing deps

### DIFF
--- a/overrides/config/ftbquests/quests/chapters/burning_the_veil_iv.snbt
+++ b/overrides/config/ftbquests/quests/chapters/burning_the_veil_iv.snbt
@@ -913,6 +913,7 @@
 			y: -10.5d
 		}
 		{
+			dependencies: ["52DAB014D2101F02"]
 			id: "4D67B518EE125AAC"
 			tasks: [{
 				id: "343BA877F7C376B5"
@@ -934,6 +935,7 @@
 			y: -11.5d
 		}
 		{
+			dependencies: ["52DAB014D2101F02"]
 			id: "043120D48405BC84"
 			tasks: [{
 				id: "57DAC5B2B7AAF204"

--- a/overrides/config/ftbquests/quests/chapters/worth_every_ingot.snbt
+++ b/overrides/config/ftbquests/quests/chapters/worth_every_ingot.snbt
@@ -18,6 +18,7 @@
 	quest_links: [ ]
 	quests: [
 		{
+			dependencies: ["57003172615D5C1D"]
 			dependency_requirement: "one_completed"
 			description: [
 				"I seriously recommend you upgrade your Naqline, as there is SEVERAL Naquadah sinks in LuV."


### PR DESCRIPTION
(n23) Hydroxybenzoic and Naphthoxide quests were missing deps in IV, as well as LuV machine hull, making the IV, LuV and ZPM chapters be shown at start of game 

verified that this patch hides those quests 