### PR TITLE
Fix Iron rate in Chromite line

### DIFF
--- a/overrides/kubejs/server_scripts/Recipes/Chains/Chromite.js
+++ b/overrides/kubejs/server_scripts/Recipes/Chains/Chromite.js
@@ -49,7 +49,7 @@ ServerEvents.recipes(event => {
         .itemInputs('14x gtceu:chromite_dust')
         .inputFluids('gtceu:oxygen 7000')
         .inputFluids('gtceu:sodium_carbonate_solution 4000')
-        .itemOutputs('7x gtceu:magnetite_dust')
+        .itemOutputs('5x gtceu:hematite_dust')
         .outputFluids('gtceu:carbon_dioxide 4000')
         .outputFluids('gtceu:sodium_chromate_solution 4000')
         .duration(120)


### PR DESCRIPTION
14 Chromite Dust should be 2 Iron Dust but 7 Magnetite is 3 Iron Dust.

~This change also has the effect of increasing the Oxygen cost per 14 Chromite Dust from 5 B to 6 B, which means that the line will consume exactly 6 B of Water per 14 Chromite Dust instead of generating Oxygen or requiring an extra source of Hydrogen.~