### PR TITLE
Reposition dark mode button

### DIFF
--- a/overrides/config/darkmodeeverywhere-client.toml
+++ b/overrides/config/darkmodeeverywhere-client.toml
@@ -11,11 +11,11 @@ METHOD_SHADER_DUMP = false
 	#Pixels away from the left of the GUI in the x axis
 	# Default: 32
 	# Range: > 0
-	X = 32
+	X = 2
 	#Pixels away from the bottom of the GUI in the y axis
 	# Default: 2
 	# Range: > 0
-	Y = 2
+	Y = 24
 
 ["Main Menu Button"]
 	#Enabled


### PR DESCRIPTION
Repositions dark mode button to not overlap with EMI buttons

<hr>

Before

<img width="238" height="98" alt="image" src="https://github.com/user-attachments/assets/ffc561cc-e7df-4538-bb90-9efdbe7912ac" />

After
<img width="219" height="159" alt="image" src="https://github.com/user-attachments/assets/dbcfe347-96bc-40a8-8a98-e9181a475a1d" />
