### PR TITLE
Move Just Zoom icon to bottom right

### DIFF
--- a/overrides/config/justzoom/config.txt
+++ b/overrides/config/justzoom/config.txt
@@ -13,5 +13,5 @@ B:normalize_mouse_sensitivity_on_zoom = 'true';
 
 ##[gui]
 
-I:options_button_corner = '0';
+I:options_button_corner = '1';
 B:show_options_button_in_pause_screen = 'true';


### PR DESCRIPTION
Repositions Just Zoom's options icon to the bottom right of the pause screen to prevent conflict with Tips

Before
<img width="1919" height="1079" alt="image" src="https://github.com/user-attachments/assets/56c03308-cf10-4e57-9b95-ffaf45c2e4d5" />

After
<img width="1919" height="1079" alt="image" src="https://github.com/user-attachments/assets/7aec6522-5ec4-46f2-ae55-bd238cbfd034" />
