### PR TITLE
Add Ultimine groups for Malum woods

### DIFF
--- a/overrides/config/ftbultimine-server.snbt
+++ b/overrides/config/ftbultimine-server.snbt
@@ -75,6 +75,8 @@
 			"minecraft:base_stone_overworld"
 			"c:ores/*"
 			"forge:ores/*"
+			"cosmicfrontiers:soulwood_ultimine_group"
+			"cosmicfrontiers:runewood_ultimine_group"
 		]
 		
 		# These tags will be considered the same block when checking for blocks to Ultimine in shaped mining modes

--- a/overrides/kubejs/server_scripts/Tags.js
+++ b/overrides/kubejs/server_scripts/Tags.js
@@ -1,4 +1,4 @@
-ServerEvents.tags('item', event => {
+ServerEvents.tags('block', event => {
     event.add('cosmicfrontiers:runewood_ultimine_group', ['malum:runewood_log', 'malum:exposed_runewood_log'])
     event.add('cosmicfrontiers:soulwood_ultimine_group', ['malum:soulwood_log', 'malum:exposed_soulwood_log'])
 })

--- a/overrides/kubejs/server_scripts/Tags.js
+++ b/overrides/kubejs/server_scripts/Tags.js
@@ -1,4 +1,4 @@
-ServerEvents.tags(event => {
+ServerEvents.tags('item', event => {
     event.add('cosmicfronters:runewood_ultimine_group', ['malum:runewood_log', 'malum:exposed_runewood_log'])
     event.add('cosmicfronters:soulwood_ultimine_group', ['malum:soulwood_log', 'malum:exposed_soulwood_log'])
 })

--- a/overrides/kubejs/server_scripts/Tags.js
+++ b/overrides/kubejs/server_scripts/Tags.js
@@ -1,0 +1,4 @@
+ServerEvents.tags(event => {
+    event.add('cosmicfronters:runewood_ultimine_group', ['malum:runewood_log', 'malum:exposed_runewood_log'])
+    event.add('cosmicfronters:soulwood_ultimine_group', ['malum:soulwood_log', 'malum:exposed_soulwood_log'])
+})

--- a/overrides/kubejs/server_scripts/Tags.js
+++ b/overrides/kubejs/server_scripts/Tags.js
@@ -1,4 +1,4 @@
 ServerEvents.tags('item', event => {
-    event.add('cosmicfronters:runewood_ultimine_group', ['malum:runewood_log', 'malum:exposed_runewood_log'])
-    event.add('cosmicfronters:soulwood_ultimine_group', ['malum:soulwood_log', 'malum:exposed_soulwood_log'])
+    event.add('cosmicfrontiers:runewood_ultimine_group', ['malum:runewood_log', 'malum:exposed_runewood_log'])
+    event.add('cosmicfrontiers:soulwood_ultimine_group', ['malum:soulwood_log', 'malum:exposed_soulwood_log'])
 })


### PR DESCRIPTION
Originally a feature from 1.20.1 that let you Ultimine entire Malum trees by adding exposed wood blocks to the same group as normal wood blocks