### PR TITLE
Remove Enchanted Golden Apple recipe in crafting table

### DIFF
--- a/overrides/kubejs/server_scripts/Recipes/RecipeRemovals.js
+++ b/overrides/kubejs/server_scripts/Recipes/RecipeRemovals.js
@@ -362,6 +362,8 @@ ServerEvents.recipes(event => {
     event.remove({ output: 'metalbarrels:obsidian_barrel' })
     event.remove({ output: 'metalbarrels:netherite_barrel' })
 
+    event.remove({ id: 'bhc:enchanted_golden_apple' })
+
     //   event.remove({ id: '' })
     //   event.remove({ id: '' })
     //   event.remove({ id: '' })


### PR DESCRIPTION
## Changes
Removes Enchanted Golden Apple recipe in a crafting table added by the Baubley Heart Canisters mod.

---

*AI disclosure: an agent was used to do research. All changes were made by a human.*

Fixes #914