### PR TITLE
Reposition Dark mode inventory button

### DIFF
--- a/overrides/config/darkmodeeverywhere-client.toml
+++ b/overrides/config/darkmodeeverywhere-client.toml
@@ -11,11 +11,11 @@ METHOD_SHADER_DUMP = false
 	#Pixels away from the left of the GUI in the x axis
 	# Default: 32
 	# Range: > 0
-	X = 2
+	X = 46
 	#Pixels away from the bottom of the GUI in the y axis
 	# Default: 2
 	# Range: > 0
-	Y = 24
+	Y = 3
 
 ["Main Menu Button"]
 	#Enabled


### PR DESCRIPTION
## Changes
The Dark mode inventory button is put in the same row as the EMI buttons to avoid overlapping with other GUI parts.

<img width="1383" height="691" alt="image" src="https://github.com/user-attachments/assets/315ec642-dbf7-4aa5-9b94-4652816d710e" />

---

*AI disclosure: AI was used to make changes to the config. All changes were reviewed and tested by a human.*

Fixes #917


